### PR TITLE
Use the more appropriate 409 status code for duplicates

### DIFF
--- a/lib/pause_1999/edit.pm
+++ b/lib/pause_1999/edit.pm
@@ -1976,6 +1976,7 @@ Reason:</b></p><p>$errmsg</p>
 
 });
 	if ($errmsg =~ /non\s+unique\s+key|Duplicate/i) {
+          $r->status(409);
           my $sth = $dbh->prepare("SELECT * FROM uris WHERE uriid=?");
           $sth->execute($uriid);
           my $rec = $mgr->fetchrow($sth, "fetchrow_hashref");


### PR DESCRIPTION
406 is not bad, but for this particular kind of error 409 (Conflict) seems even
better.
