### PR TITLE
Add \.json to the regexp for allowing overwrites

### DIFF
--- a/htdocs/04pause.html
+++ b/htdocs/04pause.html
@@ -45,7 +45,7 @@ number</b>. For security reasons you will never be able to upload a
 file with identical name again. This strict requirement does have one
 exception: documentation files may be overwritten. There's a simple
 regular expression that draws the line between docu and code:
-<code>/(readme|\.html|\.txt|\.[xy]ml|\.[pr]df|\.pod)$/i</code><!--
+<code>/(readme|\.html|\.txt|\.[xy]ml|\.json|\.[pr]df|\.pod)(\.gz|\.bz2)?$/i</code><!--
 see pause_1999/edit.pm: ALLOW_OVERWRITE -->. Filenames matching this
 regexp can be uploaded as often as you like. By the way: it is highly
 appreciated if your packages come tarred and gzipped with a

--- a/lib/pause_1999/edit.pm
+++ b/lib/pause_1999/edit.pm
@@ -1852,7 +1852,7 @@ href="mailto:},
       }
 
     ALLOW_OVERWRITE: if (
-	  $filename =~ /(readme|\.html|\.txt|\.[xy]ml|\.[pr]df|\.pod)(\.gz|\.bz2)?$/i
+	  $filename =~ /(readme|\.html|\.txt|\.[xy]ml|\.json|\.[pr]df|\.pod)(\.gz|\.bz2)?$/i
           ||
           $uriid =~ m!^C/CN/CNANDOR/(?:mp_(?:app|debug|doc|lib|source|tool)|VISEICat(?:\.idx)?|VISEData)!
 	 ) {


### PR DESCRIPTION
Since xml and yaml (yml) were already in the list
json seemed like a reasonable addition.

Specifically the metacpan project (@CPAN-API) recently made this change:

> Instead of forking the repository we require the authors to upload the file to their PAUSE root directory.
> Our indexer will then fetch the CPAN and index the information.
> 
> You can find your file at https://github.com/CPAN-API/cpan-api/tree/3ad5ad8506c18e4bc3caa6c1489db694e600dcb5/conf/authors/id
> 
> Since you cannot overwrite a file on the CPAN you have to add a version string to it.
> The files are called author-1.0.json by default. Please change it to a new version if you add any changes.
