### PR TITLE
rewrite indexes after a new upload enters PAUSE

### DIFF
--- a/lib/PAUSE/mldistwatch.pm
+++ b/lib/PAUSE/mldistwatch.pm
@@ -163,8 +163,22 @@ sub reindex {
     $self->checkfornew($testdir);
     chdir $startdir or die "Could not chdir to '$startdir'";
     rmtree $testdir;
-    return if $self->{OPT}{pick};
-    $self->rewrite_indexes;
+    return $self->{OPT}{pick} ? $self->rewrite_module_indexes : $self->rewrite_indexes;
+}
+
+# only rewrite those indexes, which needs update after a new upload
+sub rewrite_module_indexes {
+  my $self = shift;
+  $self->rewrite02();
+  my $MLROOT = $self->mlroot;
+  chdir $MLROOT
+      or die "Couldn't chdir to $MLROOT: $!";
+  $self->rewrite01();
+  $self->rewrite06();
+  $self->verbose(1, sprintf(
+                            "Finished rewrite03 and everything at %s\n",
+                            scalar localtime
+                           ));
 }
 
 sub rewrite_indexes {


### PR DESCRIPTION
  the main motivation behind this is metacpan. It relies on
  the 02package.details.txt file to provide which modules are
  considered 'latest'. Currently, the generation of this file
  lags behind because it's generated once an hour. This patch
  will regenerate this file (and others) with every upload to
  pause. This has benefits for the whole cpan toolchain as well.
  Command line tools like `cpan` will be able to install versions
  of recently uploaded releases immediately (after getting the
  up-to-date 02packages file).
  I'm aware of the fact that this will put some additional load
  on the box and requires more bandwidth for rrr mirrors. But
  considering the pro and cons, I think it's worth it.
