### PR TITLE
skip ./local and ./perl5 for non-meta indexing

### DIFF
--- a/lib/PAUSE/dist.pm
+++ b/lib/PAUSE/dist.pm
@@ -645,7 +645,13 @@ sub filter_pms {
   MANI: for my $mf ( @{$self->{MANIFOUND}} ) {
     next unless $mf =~ /\.pm(?:\.PL)?$/i;
     my($inmf) = $mf =~ m!^[^/]+/(.+)!; # go one directory down
-    next if $inmf =~ m!^(?:t|inc)/!;
+
+    # skip "t" - libraries in ./t are test libraries!
+    # skip "inc" - libraries in ./inc are usually install libraries
+    # skip "local" - somebody shipped his carton setup!
+    # skip 'perl5" - somebody shipped her local::lib!
+    next if $inmf =~ m!^(?:t|inc|local|perl5)/!;
+
     if ($self->{META_CONTENT}){
       my $no_index = $self->{META_CONTENT}{no_index}
       || $self->{META_CONTENT}{private}; # backward compat


### PR DESCRIPTION
Yesterday, someone accidentally uploaded a dist with his local::lib in it, which included a lot of libraries not meant to be included in his dist.  Unfortunately, the uploader was comaint on these, which meant they were then indexed, leading to serious problems.

This commit excludes "local" (used by carton) and "perl5" (used by some local installers) from non-meta-driven index, much like "t" and "inc" are already excluded.

This is _not_ a perfect solution to this kind of problem, but may help and should not hurt.
