### PR TITLE
Fix XHTML DOCTYPE

### DIFF
--- a/cron/cron-daily.pl
+++ b/cron/cron-daily.pl
@@ -388,7 +388,7 @@ sub whois {
   }
   my $now = gmtime;
   print FH
-    qq{<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "DTD/xhtml1-transitional.dtd"><html><!-- -*- coding: utf-8 -*- --><head>
+    qq{<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><!-- -*- coding: utf-8 -*- --><head>
 <title>who is who on the perl module list</title></head>
 <body>
   <h3>People, <a href="#mailinglists">Mailinglists</a> And

--- a/htdocs/00modlist.long.html
+++ b/htdocs/00modlist.long.html
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><!-- -*- coding: utf-8 -*- --><head><title>The Perl 5 Registered Module List</title><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" /></head><body>
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><!-- -*- coding: utf-8 -*- --><head><title>The Perl 5 Registered Module List</title><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" /></head><body>
 <h1>The Perl 5 Registered Module List</h1>
 Maintained by Tim Bunce and Andreas K&ouml;nig <a href="mailto:modules@perl.org">&lt;modules@perl.org&gt;</a>;<br />
 <i> $Rev$ $Date$ -*- coding:utf-8 -*-</i><br />

--- a/htdocs/04pause.html
+++ b/htdocs/04pause.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html
  PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
- "DTD/xhtml1-transitional.dtd">
+ "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head><title>PAUSE</title></head><body>
 <h2><a href="https://pause.perl.org/pause/">The [Perl programming] Authors Upload Server</a></h2>

--- a/htdocs/history.html
+++ b/htdocs/history.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html
  PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
- "DTD/xhtml1-transitional.dtd">
+ "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head><title>PAUSE history</title></head>
   <body>

--- a/htdocs/imprint.html
+++ b/htdocs/imprint.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html
  PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
- "DTD/xhtml1-transitional.dtd">
-<html>
+ "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head><title></title></head><body>
 <p>(page required by German law)</p>
 Andreas K&#x00f6;nig<br />

--- a/htdocs/logout.html
+++ b/htdocs/logout.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html
  PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
- "DTD/xhtml1-transitional.dtd">
+ "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head><title></title></head>
   <body>

--- a/htdocs/password.html
+++ b/htdocs/password.html
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!DOCTYPE html
  PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
- "DTD/xhtml1-transitional.dtd"><html>
+ "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
  <head>
   <title>Passwords on the PAUSE</title>
  </head>

--- a/lib/PAUSE/mldistwatch.pm
+++ b/lib/PAUSE/mldistwatch.pm
@@ -810,7 +810,9 @@ sub rewrite01 {
     }
     $list = qq{<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><title>Modules
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head><title>Modules
 on CPAN alphabetically</title></head><body>
 <h1>CPAN\'s $count modules distributions</h1>
 <h3>in alphabetical order by modules contained in the distributions</h3>

--- a/lib/pause_1999/layout.pm
+++ b/lib/pause_1999/layout.pm
@@ -28,7 +28,7 @@ sub layout {
     }
     push @l, qq{<!DOCTYPE html
                  PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-                 "DTD/xhtml1-transitional.dtd">};
+                 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">};
   }
   push @l, qq{<html xmlns="http://www.w3.org/1999/xhtml"><head><title>};
   push @l, $PAUSE::Config->{TESTHOST} ? qq{pause\@home: } : qq{PAUSE: };


### PR DESCRIPTION
This patch fixes incorrect System Identifier part of the DOCTYPE reported as a warning by the W3C Validator. It also fixes a few case of missing `xmlns` in XHTML documents.
See for example [the W3C Validator report for `htdocs/imprint.html`](http://validator.w3.org/check?verbose=1&uri=http%3A%2F%2Fpause.perl.org%2Fimprint.html) that show both issues.
