### PR TITLE
exclude pms in xt directory as well

### DIFF
--- a/lib/PAUSE/dist.pm
+++ b/lib/PAUSE/dist.pm
@@ -673,10 +673,11 @@ sub filter_pms {
     my($inmf) = $mf =~ m!^[^/]+/(.+)!; # go one directory down
 
     # skip "t" - libraries in ./t are test libraries!
+    # skip "xt" - libraries in ./xt are author test libraries!
     # skip "inc" - libraries in ./inc are usually install libraries
     # skip "local" - somebody shipped his carton setup!
     # skip 'perl5" - somebody shipped her local::lib!
-    next if $inmf =~ m!^(?:t|inc|local|perl5)/!;
+    next if $inmf =~ m!^(?:x?t|inc|local|perl5)/!;
 
     if ($self->{META_CONTENT}){
       my $no_index = $self->{META_CONTENT}{no_index}


### PR DESCRIPTION
Hi. In theory it may not be a good idea to include xt directory (for author-only tests) in a dist, but as it is sometimes included, it's nice to exclude pmfiles in it.
