### PR TITLE
stop @cols from being empty

### DIFF
--- a/lib/PAUSE/mldistwatch.pm
+++ b/lib/PAUSE/mldistwatch.pm
@@ -1060,6 +1060,12 @@ sub rewrite03 {
     } else {
         $self->verbose(1,"No 03modlists exist; won't try to read it");
     }
+
+    my @cols = qw(
+      modid statd stats statl
+      stati statp description userid chapterid
+    );
+
     my $date = HTTP::Date::time2str();
     my $dbh = $self->connect;
     my $sth = $dbh->prepare(qq{
@@ -1104,7 +1110,7 @@ Date:        %s
 !;
 
     $list .= Data::Dumper->new([
-                                $sth->{NAME},
+                                \@cols,
                                 $modlist_data,
                                ],
                                ["CPAN::Modulelist::cols",


### PR DESCRIPTION
this was relying on something in the DBD::mysql that seems to
have changed; without this, the data in 03packages cannot be
accessed

CPANPLUS is broken right now because of this problem.

I _believe_ this will fix it.
