### PR TITLE
parse_version_safely should also ignore DATA/END section

### DIFF
--- a/lib/PAUSE/pmfile.pm
+++ b/lib/PAUSE/pmfile.pm
@@ -313,6 +313,9 @@ sub packages_per_pmfile {
         while (<FH>) {
             $inpod = /^=(?!cut)/ ? 1 : /^=cut/ ? 0 : $inpod;
             next if $inpod || /^\s*#/;
+            last if (/\b__(?:END|DATA)__\b/
+                and $parsefile !~ /\.PL$/   # PL files may well have code after __DATA__
+            );
             chop;
             # next unless /\$(([\w\:\']*)\bVERSION)\b.*\=/;
             next unless /([\$*])(([\w\:\']*)\bVERSION)\b.*\=/;


### PR DESCRIPTION
Hi.

I find Mojolicious::Command::generate::plugin is listed in 02packages.details.txt as version 0.01, though it only has a $VERSION line in its DATA section.

https://metacpan.org/source/SRI/Mojolicious-4.10/lib/Mojolicious/Command/generate/plugin.pm#L35

This branch should fix the issue. I'm sorry I haven't written any test for this. I only tested this with Parse::PMFile which I borrowed a lot of code from pause.
