### PR TITLE
Ignore meta json in subdir

### DIFF
--- a/lib/PAUSE/dist.pm
+++ b/lib/PAUSE/dist.pm
@@ -902,7 +902,7 @@ sub extract_readme_and_meta {
     return;
   }
 
-  # META.json located only in a subdirectory should not be preceded
+  # META.json located only in a subdirectory should not precede
   # META.yml located in the top directory. (eg. Test::Module::Used 0.2.4)
   if ($json && $yaml && length($json) > length($yaml) + 1) {
     $json = '';


### PR DESCRIPTION
Currently, META.json precedes META.yml unconditionally. This is usually ok as both META.json and META.yml are usually located in the top directory, but I found a (rare) case (Test::Module::Used 0.2.4) where META.json is located in a subdirectory and only META.yml is located in the top directory. In this case, META.yml should have precedence.
