### PR TITLE
ignore a variable called 'package'

### DIFF
--- a/lib/PAUSE/pmfile.pm
+++ b/lib/PAUSE/pmfile.pm
@@ -219,6 +219,7 @@ sub packages_per_pmfile {
         if (
             $pline =~ m{
                       (.*)
+                      (?<![*\$\\@%&]) # no sigils
                       \bpackage\s+
                       ([\w\:\']+)
                       \s*


### PR DESCRIPTION
Hi. Though this is quite rare, but a statement like the following was wrongly deteted as a package (named 'or').

```
$package or
  die;
```

See also this commit for Parse::PMFile for a test. This was found while parsing the following module: 

https://metacpan.org/source/MSIMERSON/Mail-Toaster-5.42/lib/Mail/Toaster/Utility.pm#L1364
