### PR TITLE
deref a version set as *VERSION = \...

### DIFF
--- a/lib/PAUSE/pmfile.pm
+++ b/lib/PAUSE/pmfile.pm
@@ -456,8 +456,9 @@ sub parse_version {
                 my $err = $@;
                 # warn ">>>>>>>err[$err]<<<<<<<<";
                 if (ref $err) {
-                    if ($err->{line} =~ /[\$*]([\w\:\']*)\bVERSION\b.*\=(.*)/) {
-                        $v = $comp->reval($2);
+                    if ($err->{line} =~ /([\$*])([\w\:\']*)\bVERSION\b.*\=(.*)/) {
+                        $v = $comp->reval($3);
+                        $v = $$v if $1 eq '*' && ref $v eq ref \"";
                     }
                     if ($@) {
                         warn sprintf("reval failed: err[%s] for eval[%s]",


### PR DESCRIPTION
$v here in line 460 should be a scalar reference when the left part is *VERSION, and should be dereferenced before it is passed to the parent. An example to test is Acme::Lvalue 0.03 (which is still on CPAN).
