### PR TITLE
undefined provides package version should always be 'undef' no matter if it exists or not

### DIFF
--- a/lib/PAUSE/pmfile.pm
+++ b/lib/PAUSE/pmfile.pm
@@ -256,7 +256,7 @@ sub packages_per_pmfile {
                 if ($self->version_from_meta_ok) {
                     my $provides = $self->{DIO}{META_CONTENT}{provides};
                     if (exists $provides->{$pkg}) {
-                        if (exists $provides->{$pkg}{version}) {
+                        if (defined $provides->{$pkg}{version}) {
                             my $v = $provides->{$pkg}{version};
                             if ($v =~ /[_\s]/){   # ignore developer releases and "You suck!"
                                 next PLINE;


### PR DESCRIPTION
Sometimes "provides" package version may become explicit undef, which passes the "exists" test in line 259 and causes an unini warning in line 261.
