### PR TITLE
undefined $indexingrule caused uuv in numeric eq (==) warnings

### DIFF
--- a/lib/PAUSE/dist.pm
+++ b/lib/PAUSE/dist.pm
@@ -749,7 +749,8 @@ sub examine_pms {
   $binary_dist = 1 if $dist =~ /\d-bin-\d+-/i;
 
   my $pmfiles = $self->filter_pms;
-  my($meta,$provides,$indexingrule);
+  my($meta,$provides);
+  my $indexingrule = 0;
   if (my $version_from_meta_ok = $self->version_from_meta_ok) {
     $meta = $self->{META_CONTENT};
     $provides = $meta->{provides};


### PR DESCRIPTION
When $indexingrule is not set because of the lack of .pm files, it causes unini warnings later in line 764 etc.
