### PR TITLE
VERSION comparison shouldn't be detected as VERSION definition

### DIFF
--- a/lib/PAUSE/pmfile.pm
+++ b/lib/PAUSE/pmfile.pm
@@ -317,7 +317,7 @@ sub packages_per_pmfile {
             last if /^__(?:END|DATA)__\b/; # fails on quoted __END__ but this is rare -> __END__ in the middle of a line is rarer
             chop;
             # next unless /\$(([\w\:\']*)\bVERSION)\b.*\=/;
-            next unless /([\$*])(([\w\:\']*)\bVERSION)\b.*\=/;
+            next unless /([\$*])(([\w\:\']*)\bVERSION)\b.*(?<![!><=])\=(?![=>])/;
             my $current_parsed_line = $_;
             my $eval = qq{
           package ExtUtils::MakeMaker::_version;


### PR DESCRIPTION
An example to test is https://metacpan.org/source/DOY/KiokuDB-0.54/lib/KiokuDB/Util.pm#L179 . This kind of version comparison shouldn't be detected as VERSION definition.
