### PR TITLE
skip if provides file field is empty

### DIFF
--- a/lib/PAUSE/dist.pm
+++ b/lib/PAUSE/dist.pm
@@ -787,6 +787,8 @@ sub examine_pms {
     }
   } elsif (2==$indexingrule) { # a yaml with provides
     while (my($k,$v) = each %$provides) {
+      next if ref $v ne ref {};
+      next if !defined $v->{file} or $v->{file} eq '';
       $v->{infile} = "$v->{file}";
       my @stat = stat File::Spec->catfile($self->{DISTROOT}, $v->{file});
       if (@stat) {


### PR DESCRIPTION
An example to test is https://metacpan.org/source/RIBASUSHI/DBIx-Class-Manual-SQLHackers-1.3/META.yml#L23 . Empty file field causes several troubles such as bogus stats etc.
