### PR TITLE
do not scan past __END__ on .pm.PL files

### DIFF
--- a/lib/PAUSE/pmfile.pm
+++ b/lib/PAUSE/pmfile.pm
@@ -207,7 +207,7 @@ sub packages_per_pmfile {
 
         $pline =~ s/\#.*//;
         next if $pline =~ /^\s*$/;
-        if ($pline =~ /^__(?:END|DATA)__\b/
+        if ($pline =~ /^__DATA__\b/
             and $pmfile !~ /\.PL$/   # PL files may well have code after __DATA__
             ){
             last PLINE;


### PR DESCRIPTION
It makes sense to scan the DATA section for a .pm.PL file, since so
often the DATA contains a template.

This won't happen with **END**.  We should keep our hands off it.
