### PR TITLE
do not show PAUSE work logs while testing

### DIFF
--- a/t/lib/PAUSE/TestPAUSE.pm
+++ b/t/lib/PAUSE/TestPAUSE.pm
@@ -119,6 +119,8 @@ sub _build_pause_config_overrides {
     ML_MIN_INDEX_LINES => 1,
     MOD_DATA_SOURCE_NAME => "$dsnbase/mod.sqlite",
     PID_DIR              => $pid_dir,
+
+    ($ENV{TEST_VERBOSE} ? () : (LOG_CALLBACK => sub { })),
   };
 
   return $overrides;


### PR DESCRIPTION
...unless you ran with TEST_VERBOSE (like prove -v)
