### PR TITLE
brace after 'package NAME' should be an open brace, not a close brace

### DIFF
--- a/lib/PAUSE/pmfile.pm
+++ b/lib/PAUSE/pmfile.pm
@@ -223,7 +223,7 @@ sub packages_per_pmfile {
                       \bpackage\s+
                       ([\w\:\']+)
                       \s*
-                      (?: $ | [\}\;] | { | \s+($version::STRICT) )
+                      (?: $ | [\}\;] | \{ | \s+($version::STRICT) )
                     }x) {
             $pkg = $2;
             $strict_version = $3;


### PR DESCRIPTION
- `package NAME` is ok  (maybe something follows)
- `package NAME;` is ok.
- `package NAME }` is ok (same as ;, though looks weird).
- `package NAME VERSION` is ok.
- `package NAME BLOCK` is not supported now.

This fix address the last one so that it can parse `package NAME BLOCK` correctly.

cf. perldoc -f package

```
    package NAMESPACE
    package NAMESPACE VERSION
    package NAMESPACE BLOCK
    package NAMESPACE VERSION BLOCK
```
