### PR TITLE
if we cannot determine package owner, say "unknown"

### DIFF
--- a/lib/PAUSE/package.pm
+++ b/lib/PAUSE/package.pm
@@ -196,7 +196,9 @@ sub perm_check {
           # seems ok: perl is always right
       } elsif (! grep { $_ eq $userid } @owner) {
           # we must not index this and we have to inform somebody
-          my $owner = eval { PAUSE::owner_of_module($package, $dbh) };
+          my $owner = eval { PAUSE::owner_of_module($package, $dbh) }
+                    // "unknown";
+
           $self->index_status($package,
                               $pp->{version},
                               $pp->{infile},


### PR DESCRIPTION
Sometimes we get a module uploaded for a dist that has maintainers, but no primary.  In this case, we should say we don't know the owner, rather than an empty string and a warning.

(In the future, this can be improved to give a list of co-maints.)
