### PR TITLE
allow math functions to specify VERSION (fix #86)

### DIFF
--- a/lib/PAUSE/pmfile.pm
+++ b/lib/PAUSE/pmfile.pm
@@ -446,6 +446,7 @@ sub parse_version {
                                         '*Exporter::',
                                         '*DynaLoader::']);
             $comp->share_from('version', ['&qv']);
+            $comp->permit(":base_math");
             # $comp->permit("require"); # no strict!
             {
                 no strict;


### PR DESCRIPTION
- Acme::Pi uses `atan2` to specify its version.
