### PR TITLE
ensure that Perl6 dists go into a Perl6 sub directory

### DIFF
--- a/bin/paused
+++ b/bin/paused
@@ -880,8 +880,9 @@ sub is_perl6_tarball {
 sub get_perl6_lpath {
   my ($self, $mlroot, $uriid) = @_;
   # enforce the Perl6 subdirectory to not mess with Perl5 distributions
-  if ($uriid =~ m,^([^/]+/[^/]+/[^/]+)/(.*/)?([^/]+)$,) {
-    my ($path, $file) = ("$mlroot$1/Perl6", $3);
+  if ($uriid =~ m,^([^/]+/[^/]+/[^/]+)/(.+)$,) {
+    my ($path, $file) = ("$mlroot$1", $2);
+    $path .= '/Perl6' unless $file =~ m,^Perl6/,i;
     File::Path::mkpath($path);
     return "$path/$file"
   } else {


### PR DESCRIPTION
We do this to not mess with Perl5 distributions, so that smokers can easily
filter distributions by path to not smoke Perl6 dists accidently.

Note that this means that the target directory one can specify when uploading
a dist is ignored for Perl6.
The tarball will always go to A/AU/AUTHOR/Perl6/<filename>.
