### PR TITLE
ensure that Perl6 dists go into a Perl6 sub directory

### DIFF
--- a/bin/paused
+++ b/bin/paused
@@ -881,10 +881,12 @@ sub get_perl6_lpath {
   my ($self, $mlroot, $uriid) = @_;
   # enforce the Perl6 subdirectory to not mess with Perl5 distributions
   if ($uriid =~ m,^([^/]+/[^/]+/[^/]+)/(.+)$,) {
-    my ($path, $file) = ("$mlroot$1", $2);
-    $path .= '/Perl6' unless $file =~ m,^Perl6/,i;
+    my ($path, $subpath) = ("$mlroot$1", $2);
+    # make sure we don't end up with duplicate Perl6/Perl6 or Perl6/perl6 folders.
+    $subpath =~ s,^Perl6/,,i;
+    $path   .= '/Perl6';
     File::Path::mkpath($path);
-    return "$path/$file"
+    return "$path/$subpath"
   } else {
     # this directory has already been made
     return "$mlroot$uriid"


### PR DESCRIPTION
We do this to not mess with Perl5 distributions so that smokers can easily
filter distributions by path to not smoke Perl6 dists accidently.

Note that this means that the target directory one can specify when uploading
a dist is put inside a "Perl6" directory, like in:
A/AU/AUTHOR/Perl6/&lt;optional directories>/&lt;filename>.
