### PR TITLE
index Perl 6 dists into table p6dists, p6provides and p6binaries

### DIFF
--- a/lib/PAUSE/mldistwatch.pm
+++ b/lib/PAUSE/mldistwatch.pm
@@ -452,8 +452,18 @@ sub check_for_new {
           }
 
           if ($dio->perl_major_version == 6) {
-            # XXX do something sensible for Perl6
-            $dbh->commit;
+            if ($dio->p6_dist_meta_ok) {
+              if (my $err = $dio->p6_index_dist) {
+                $dio->alert($err);
+                $dbh->rollback;
+              } else {
+                $dbh->commit;
+              }
+            }
+            else {
+              $dio->alert("Meta information of Perl 6 dist $dist is invalid");
+              $dbh->rollback;
+            }
           } else {
             $dio->examine_pms;      # will switch user
 


### PR DESCRIPTION
Right now we only disallow duplicate releases from the same author,
more rules will be added after this patch got applied. One reason
for this is that we cannot easily parse Perl 6 version literals in
Perl 5, at least not today.
