### PR TITLE
s/ftp:/http:/ for localhost. ( Temporary fix )

### DIFF
--- a/lib/PAUSE.pm
+++ b/lib/PAUSE.pm
@@ -99,7 +99,7 @@ $PAUSE::Config ||=
      HOME => $IS_PAUSE_US ? '/home/puppet/' : '/home/k/',
      CRONPATH => $IS_PAUSE_US ? '/home/puppet/pause/cron' : '/home/k/pause/cron',
      HTTP_ERRORLOG => '/usr/local/apache/logs/error_log', # harmless use in cron-daily
-     INCOMING => $IS_PAUSE_US ? 'ftp://localhost/incoming/' : 'ftp://pause.perl.org/incoming/',
+     INCOMING => $IS_PAUSE_US ? 'http://localhost/incoming/' : 'http://pause.perl.org/incoming/',
      INCOMING_LOC => '/home/ftp/incoming/',
      LOG_CALLBACK => sub {
        # $entity: entity from which to grab log configuration


### PR DESCRIPTION
Assuming this is what its using as the primary "get this resource" URI,
 this transposition should temporarily fix the problem till the ftp server comes back.

 == Pause will work without all the faffing around.

As I've tested here: https://github.com/madsen/cpan-once-a-week-data/issues/2#issuecomment-49544778 , the HTTP server for files works just fine, just ftp isn't back yet.

So if applying this fix temporarily will happen sooner than fixing the FTP service, then PAUSE should just work.
