### PR TITLE
new blead warning exposes bogus arg to sprintf

### DIFF
--- a/lib/PAUSE/dist.pm
+++ b/lib/PAUSE/dist.pm
@@ -1150,9 +1150,11 @@ sub p6_index_dist {
   # Index distribution itself.
   my @args = ($c->{name}, $userid, $c->{version}, $dist, PAUSE->_now_string);
   my $ret  = $dbh->do($p6dists, undef, @args);
+  pop @args; # we do not use the "now string" in the sprintf below
   push @args, (defined $ret ? '' : $dbh->errstr), ($ret || '');
   $self->verbose(1,
     sprintf("Inserted into p6dists name[%s]auth[%s]ver[%s]tarball[%s]ret[%s]err[%s]\n", @args));
+
   return "ERROR in dist $dist: " . $dbh->errstr unless $ret;
 
   ###


### PR DESCRIPTION
New warnings are great!  Right?  Well, today they are!

Running the PAUSE test suite exposed a "Redundant argument in sprintf" warning.  We passed the same arguments to sprintf that we passed to a dbh execution, but sprintf didn't want them all, so it was (a) wrong (b) losing data.  I've fixed both problems with `pop`.  Woo!

You're welcome, perl 6!  Don't say I didn't do anything for you… :smile:
