### PR TITLE
Permit pumpking

### DIFF
--- a/lib/PAUSE.pm
+++ b/lib/PAUSE.pm
@@ -496,6 +496,29 @@ sub _now_string {
   return $self->_time_string(time);
 }
 
+sub user_has_pumpking_bit {
+  my ($self, $user) = @_;
+
+  use DBI;
+  my $adbh = DBI->connect(
+    $PAUSE::Config->{AUTHEN_DATA_SOURCE_NAME},
+    $PAUSE::Config->{AUTHEN_DATA_SOURCE_USER},
+    $PAUSE::Config->{AUTHEN_DATA_SOURCE_PW},
+  ) or die $DBI::errstr;
+  my $query = "SELECT * FROM grouptable
+  WHERE user= ?
+    AND ugroup='pumpking'";
+  my $sth = $adbh->prepare($query);
+  $sth->execute($user);
+
+  my $ok = $sth->rows > 0;
+
+  $sth->finish;
+  $adbh->disconnect;
+
+  return $ok;
+}
+
 1;
 
 # Local Variables:

--- a/lib/PAUSE/dist.pm
+++ b/lib/PAUSE/dist.pm
@@ -247,26 +247,17 @@ sub _examine_regular_perl {
   my $dist = $self->{DIST};
 
   my($u) = PAUSE::dir2user($dist); # =~ /([A-Z][^\/]+)/; # XXX dist2user
-  use DBI;
-  my $adbh = DBI->connect(
-    $PAUSE::Config->{AUTHEN_DATA_SOURCE_NAME},
-    $PAUSE::Config->{AUTHEN_DATA_SOURCE_USER},
-    $PAUSE::Config->{AUTHEN_DATA_SOURCE_PW},
-  ) or die $DBI::errstr;
-  my $query = "SELECT * FROM grouptable
-  WHERE user= ?
-    AND ugroup='pumpking'";
-  my $sth = $adbh->prepare($query);
-  $sth->execute($u);
-  if ($sth->rows > 0){
+
+  my $has_pumpking_bit = PAUSE->user_has_pumpking_bit($u);
+
+  if ($has_pumpking_bit){
     $skip = 0;
     $self->verbose(1,"Perl dist $dist from trusted user $u");
   } else {
     $skip = 1;
     $self->verbose(1,"*** ALERT: Perl dist $dist from untrusted user $u. Skip set to [$skip]\n");
   }
-  $sth->finish;
-  $adbh->disconnect;
+
   if ($dist =~ $SUFFQR) {
     $suffix = $1;
   } else {

--- a/lib/PAUSE/mldistwatch.pm
+++ b/lib/PAUSE/mldistwatch.pm
@@ -516,6 +516,10 @@ sub check_for_new {
 sub _userid_has_permissions_on_package {
   my ($self, $userid, $package) = @_;
 
+  if ($package eq 'perl') {
+    return PAUSE->user_has_pumpking_bit($userid);
+  }
+
   my $dbh = $self->connect;
 
   my ($has_perms) = $dbh->selectrow_array(


### PR DESCRIPTION
We discussed this in email: a pumpking-bit holder should be able to upload a new maint perl, and its single-life modules should be indexed.  For example, `Benchmark`  should point to 5.20.1, not 5.20.1, right now.  Andreas said, "I could've sworn the code worked this way already!"

Steve Hay found the old indexer report and it made things clear:  the "must have rights to package reflecting module name" was getting in the way!  I've special cased the check it uses:  when it wonders "does the uploader have rights to the package `perl`, it checks the pumpking bit rather than the module permissions list.

Once this is merged, we should re-re-index perl-5.20.1!