### PR TITLE
Give full indexing report even if dist name perm fails

### DIFF
--- a/lib/PAUSE/mldistwatch/Constants.pm
+++ b/lib/PAUSE/mldistwatch/Constants.pm
@@ -5,6 +5,7 @@ package PAUSE::mldistwatch::Constants;
 # constants used for index_status:
 use constant EDUALOLDER => 50; # pumpkings only
 use constant EDUALYOUNGER => 30; # pumpkings only
+use constant EDISTNAMEPERM => 26;
 use constant EDBERR => 25;
 use constant EDBCONFLICT => 23;
 use constant EOPENFILE => 21;
@@ -25,6 +26,7 @@ our $heading = {
   EDBERR() => "Database error",
   EDUALOLDER() => "An older dual-life module stays reference",
   EDUALYOUNGER() => "Dual-life module stays reference",
+  EDISTNAMEPERM() => "No permissions for distribution name",
   EMISSPERM() => "Permission missing",
   EMTIMEFALLING() => "Decreasing mtime on a file (category to be deprecated)",
   EOLDRELEASE() => "Release seems outdated",


### PR DESCRIPTION
This commit makes a distribution name permission failure merely add an
informative header to the message, but otherwise allows the ordinary
full content of the report.  However, any "indexed" modules are fixed up
to show that they are not indexed.

This should allow better diagnostic information when dist name problems
occur.

