### PR TITLE
More speed fixes for peek_perms and share_perms

### DIFF
--- a/lib/pause_1999/edit.pm
+++ b/lib/pause_1999/edit.pm
@@ -6356,8 +6356,9 @@ sub share_perms_scrl_remove_maintainer {
   my @all_mods = sort keys %$all_mods;
   my %labels;
   for my $m (@all_mods) {
-    my $owner = $self->owner_of_module($mgr,$m);
-    $labels{$m} = sprintf "%s => %s", $m, $owner||"?";
+    # get the owner for modlist modules that don't have first-come
+    my $owner = $all_mods->{$m} || $self->owner_of_module($mgr,$m) || '?';
+    $labels{$m} = "$m => $owner";
   }
   my $n = scalar @all_mods;
   return "--NONE--" unless $n;
@@ -6941,12 +6942,13 @@ sub all_cmods {
   my $u = shift;
   my $db = $mgr->connect;
   my(%all_mods);
-  my $sth2 = $db->prepare(qq{SELECT package
-                             FROM perms
+  my $sth2 = $db->prepare(qq{SELECT perms.package, primeur.userid
+                             FROM perms LEFT JOIN primeur
+                               ON perms.package = primeur.package
                              WHERE userid=?});
   $sth2->execute($u->{userid});
-  while (my($id) = $mgr->fetchrow($sth2, "fetchrow_array")) {
-    $all_mods{$id} = undef;
+  while (my($id, $owner) = $mgr->fetchrow($sth2, "fetchrow_array")) {
+    $all_mods{$id} = $owner;
   }
   $sth2->finish;
   \%all_mods;

--- a/lib/pause_1999/edit.pm
+++ b/lib/pause_1999/edit.pm
@@ -5832,10 +5832,10 @@ sub peek_perms {
     }
     if (@res) {
       for my $row (@res) {
-        # add the owner on column 4
+        # add the owner on column 3
         # will already be set except for co-maint modules where the
         # owner is in the modlist but not first-come
-        $row->[4] ||= $self->owner_of_module($mgr,$row->[0]);
+        $row->[3] ||= $self->owner_of_module($mgr,$row->[0]);
       }
       my @column_names = qw(module userid type owner);
       my $output_format = $cgi->param("OF");


### PR DESCRIPTION
Restore the performance win from commit 2fe5d79 that was accidentally broken in commit 3c90b40, and apply a similar fix to `share_perms`.

This speeds up getting the list of modules to relinquish co-maint from from ~2m45s to ~0.1s on my laptop.