### PR TITLE
CGI.pm dist name is now just CGI

### DIFF
--- a/lib/PAUSE/dist.pm
+++ b/lib/PAUSE/dist.pm
@@ -816,18 +816,11 @@ sub filter_pms {
   \@pmfile;
 }
 
-# This hash maps dist names to the package used to check for permission to
-# upload the dist. -- rjbs, 2013-04-14
-my %GRANDFATHERED_DIST_PKG = (
-  'CGI.pm' => 'CGI',
-);
-
 sub _package_governing_permission {
   my $self = shift;
 
   my $d = CPAN::DistnameInfo->new($self->{DIST});
   my $dist_name = $d->dist;
-  my $main_pkg  = $GRANDFATHERED_DIST_PKG{ $dist_name };
   unless ($main_pkg) {
     ($main_pkg = $dist_name) =~ s/[-+]+/::/g;
   }


### PR DESCRIPTION
Once, CGI.pm was in a dist called `CGI.pm-4.56.tar.gz`.  No more!

This special case can go away.