### PR TITLE
keep program flow the same under dry run

### DIFF
--- a/bin/from-mods-to-primeur.pl
+++ b/bin/from-mods-to-primeur.pl
@@ -127,8 +127,8 @@ MOD: for my $modid (@mods) {
                 warn "Would now try to insert $modid/$mv_userid into primeur; this may cause can_remove to be set and cause a delete of $modid in mods";
             } else {
                 $sth5->execute($modid,$mv_userid);
-                $can_remove = 1;
             }
+            $can_remove = 1;
         }
         if ($can_remove) {
             if ($Opt{"dry-run"}) {


### PR DESCRIPTION
We should act like we can remove code during a dry run, so
that the next phase of the dry run continues normally.