### PR TITLE
index single-life dev versions in core

### DIFF
--- a/cron/mldistwatch
+++ b/cron/mldistwatch
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl -w
+#!/usr/local/bin/perl
 
 =head1 NAME
 

--- a/lib/PAUSE.pm
+++ b/lib/PAUSE.pm
@@ -505,15 +505,13 @@ sub user_has_pumpking_bit {
     $PAUSE::Config->{AUTHEN_DATA_SOURCE_USER},
     $PAUSE::Config->{AUTHEN_DATA_SOURCE_PW},
   ) or die $DBI::errstr;
-  my $query = "SELECT * FROM grouptable
-  WHERE user= ?
-    AND ugroup='pumpking'";
-  my $sth = $adbh->prepare($query);
-  $sth->execute($user);
 
-  my $ok = $sth->rows > 0;
+  my ($ok) = $adbh->selectrow_array(
+    "SELECT COUNT(*) FROM grouptable WHERE user= ? AND ugroup='pumpking'",
+    undef,
+    $user,
+  );
 
-  $sth->finish;
   $adbh->disconnect;
 
   return $ok;

--- a/lib/PAUSE/Crypt.pm
+++ b/lib/PAUSE/Crypt.pm
@@ -14,7 +14,6 @@ sub hash_password {
 my(@saltset) = (qw(. /), 0..9, "A".."Z", "a".."z");
 
 sub _randchar ($) {
-  local($^W) = 0; #we get a bogus warning here
   my($count) = @_;
   my $str = "";
   $str .= $saltset[int(rand(64))] while $count--;

--- a/lib/PAUSE/pmfile.pm
+++ b/lib/PAUSE/pmfile.pm
@@ -283,7 +283,8 @@ sub packages_per_pmfile {
                     } else {
                         $ppp->{$pkg}{version} = defined $version ? $version : "";
                     }
-                    local($^W)=0;
+                    no warnings 'numeric';
+
                     $ppp->{$pkg}{version} =
                         $version
                             if ($version||0)

--- a/lib/PAUSE/pmfile.pm
+++ b/lib/PAUSE/pmfile.pm
@@ -139,9 +139,21 @@ sub examine_fio {
         }
 
         $self->{VERSION} = $version;
+
+        my $dist_is_perl = $self->{DIO}->isa_regular_perl($self->{DIO}{DIST});
+
         if ($self->{VERSION} =~ /^\{.*\}$/) {
             # JSON error message
-        } elsif ($self->{VERSION} =~ /[_\s]/){   # ignore developer releases and "You suck!"
+        } elsif ($self->{VERSION} =~ /[_\s]/ && ! $dist_is_perl) {
+            # If the pmfile seems to be a dev version, we skip it... but not if
+            # it's in perl.  Historical example:  perl-5.18.0 contains POSIX
+            # 1.32, but perl-5.20.0 contains 1.38_03.  We would then skip the
+            # new one, leaving some packages pointing at an older version of
+            # perl.
+            #
+            # We don't need to account for single- versus dual-life, because
+            # the check for dual-life packages still applies elsewhere.
+            # -- rjbs, 2015-04-18
             delete $self->{DIO};    # circular reference
             return;
         }

--- a/t/lib/PAUSE/TestPAUSE.pm
+++ b/t/lib/PAUSE/TestPAUSE.pm
@@ -137,7 +137,11 @@ sub _build_pause_config_overrides {
     MOD_DATA_SOURCE_NAME => "$dsnbase/mod.sqlite",
     PID_DIR              => $pid_dir,
 
-    ($ENV{TEST_VERBOSE} ? () : (LOG_CALLBACK => sub { })),
+    LOG_CALLBACK       => $ENV{TEST_VERBOSE}
+                        ? sub { my (undef, undef, @what) = @_;
+                                push @what, "\n" unless $what[-1] =~ m{\n$};
+                                print STDERR @what;  }
+                        : sub { },
   };
 
   return $overrides;

--- a/t/lib/PAUSE/TestPAUSE.pm
+++ b/t/lib/PAUSE/TestPAUSE.pm
@@ -6,7 +6,7 @@ use autodie;
 
 use DBI;
 use DBIx::RunSQL;
-use File::Copy::Recursive qw(dircopy);
+use File::Copy::Recursive qw(fcopy dircopy);
 use File::Path qw(make_path);
 use File::pushd;
 use File::Temp ();
@@ -72,6 +72,23 @@ sub import_author_root {
   my $cpan_root = File::Spec->catdir($self->tmpdir, 'cpan');
   my $ml_root = File::Spec->catdir($cpan_root, qw(authors id));
   dircopy($author_root, $ml_root);
+}
+
+sub upload_author_file {
+  my ($self, $author, $file) = @_;
+
+  $author = uc $author;
+  my $cpan_root  = File::Spec->catdir($self->tmpdir, 'cpan');
+  my $author_dir = File::Spec->catdir(
+    $cpan_root,
+    qw(authors id),
+    (substr $author, 0, 1),
+    (substr $author, 0, 2),
+    $author,
+  );
+
+  make_path( $author_dir );
+  fcopy($file, $author_dir);
 }
 
 has pause_config_overrides => (

--- a/t/mldistwatch.t
+++ b/t/mldistwatch.t
@@ -538,7 +538,6 @@ subtest "do not index bare .pm but report rejection" => sub {
 
   my $packages = $result->packages_data;
   ok($packages->package("POSIX"), "we index POSIX in a dev version");
-  scalar <STDIN>;
 };
 
 sub refused_index_test {

--- a/t/mldistwatch.t
+++ b/t/mldistwatch.t
@@ -519,6 +519,27 @@ subtest "do not index bare .pm but report rejection" => sub {
   );
 };
 
+# XXX
+subtest "do not index bare .pm but report rejection" => sub {
+  plan skip_all => "this test only run when perl-5.20.2.tar.gz found"
+    unless -e 'perl-5.20.2.tar.gz';
+
+  my $pause = init_test_pause;
+
+  my $initial_result = $pause->test_reindex;
+
+  my $dbh = $initial_result->connect_authen_db;
+  die "couldn't make OPRIME a pumpking"
+    unless $dbh->do("INSERT INTO grouptable (user, ugroup) VALUES ('OPRIME', 'pumpking')");
+
+  $pause->upload_author_file('OPRIME', 'perl-5.20.2.tar.gz');
+
+  my $result = $pause->test_reindex;
+
+  diag $result->tmpdir;
+  scalar <STDIN>;
+};
+
 sub refused_index_test {
   my ($code) = @_;
 

--- a/t/mldistwatch.t
+++ b/t/mldistwatch.t
@@ -536,7 +536,8 @@ subtest "do not index bare .pm but report rejection" => sub {
 
   my $result = $pause->test_reindex;
 
-  diag $result->tmpdir;
+  my $packages = $result->packages_data;
+  ok($packages->package("POSIX"), "we index POSIX in a dev version");
   scalar <STDIN>;
 };
 


### PR DESCRIPTION
If the pmfile seems to be a dev version, we skip it... but not if it's in perl.  Historical example:  perl-5.18.0 contains POSIX 1.32, but perl-5.20.0 contains 1.38_03.  We would then skip the new one, leaving some packages pointing at an older version of perl.

We don't need to account for single- versus dual-life, because the check for dual-life packages still applies elsewhere.