### PR TITLE
cope with fatal errors in manifind

### DIFF
--- a/lib/PAUSE/dist.pm
+++ b/lib/PAUSE/dist.pm
@@ -946,9 +946,16 @@ sub chown_unsafe {
 # package PAUSE::dist;
 sub read_dist {
   my $self = shift;
-  my(@manifind) = sort keys %{ExtUtils::Manifest::manifind()};
-  my $manifound = @manifind;
+
+  my @manifind;
+  my $ok = eval { @manifind = sort keys %{ExtUtils::Manifest::manifind()}; 1 };
   $self->{MANIFOUND} = \@manifind;
+  unless ($ok) {
+    $self->verbose(1,"Errors in manifind: $@");
+    return;
+  }
+
+  my $manifound = @manifind;
   my $dist = $self->{DIST};
   unless (@manifind){
     $self->verbose(1,"NO FILES! in dist $dist?");


### PR DESCRIPTION
manifind runs File::Find, which might die on recursive
symlinks; when that happens, PAUSE should not die