### PR TITLE
be stricter in when finding packages in files

### DIFF
--- a/lib/PAUSE/pmfile.pm
+++ b/lib/PAUSE/pmfile.pm
@@ -225,15 +225,16 @@ sub packages_per_pmfile {
 
         if (
             $pline =~ m{
-                      (.*)
-                      (?<![*\$\\@%&]) # no sigils
-                      \bpackage\s+
+                      ^
+                      [\s\{;]*
+                      package
+                      \s+
                       ([\w\:\']+)
                       \s*
                       (?: $ | [\}\;] | \{ | \s+($version::STRICT) )
                     }x) {
-            $pkg = $2;
-            $strict_version = $3;
+            $pkg = $1;
+            $strict_version = $2;
             if ($pkg eq "DB"){
                 # XXX if pumpkin and perl make him comaintainer! I
                 # think I always made the pumpkins comaint on DB


### PR DESCRIPTION
This will prevent us from finding a package in this line of code:

  my $x = "package Foo;";

This manifested in the wild in PRBRENAN/Math-Algebra-Symbols-1.21.tar.gz
