### PR TITLE
Add note that upload may have failed because a package is missing.

### DIFF
--- a/lib/PAUSE/dist.pm
+++ b/lib/PAUSE/dist.pm
@@ -428,6 +428,13 @@ sub mail_summary {
 
     my $inxst = $self->{INDEX_STATUS};
     if ($inxst && ref $inxst && %$inxst) {
+      unless ($inxst->{$pkg}) {
+        # Perhaps they forgot a pm file matching the dist name
+        push @m, $tf->format(qq{\n\nYou appear to be missing a .pm file
+           containing a package matching the dist name ($pkg). Adding this
+           may solve your issue.}) . "\n";
+      }
+
       for my $p ( keys %$inxst ) {
           next unless
             $inxst->{$p}{status} == PAUSE::mldistwatch::Constants::OK;

--- a/t/mldistwatch-big.t
+++ b/t/mldistwatch-big.t
@@ -142,6 +142,13 @@ subtest "distname/pkgname permission mismatch" => sub {
               qr/XFR,\s+which\s+you\s+do\s+not\s+have/,
               "email looks right",
             );
+          },
+          sub {
+            like(
+              $_[0]->{email}->as_string,
+              qr/You\s+appear.*\.pm\s+file.*dist\s+name\s+\(XFR\)/s,
+              "email looks right",
+            );
           }
         ],
       },


### PR DESCRIPTION
For GH #202.

Adds a hopefully helpful message if someone gets a permission failure when uploading a dist.

The message is:

    You appear to be missing a .pm file containing a package matching the dist name ($pkg). Adding 
    this may solve your issue.

This message may show up in some situations where it is a lie (like uploading fails because you don't actually own the dist in question).

If we want to fix that, please let me know.