### PR TITLE
set $PAUSE::Config->{SERVER_NAME} to uri->host if it is set

### DIFF
--- a/lib/pause_1999/main.pm
+++ b/lib/pause_1999/main.pm
@@ -378,6 +378,7 @@ sub myurl {
   #				 $r->server->server_hostname .
   #				 $explicit_port .
   #				 $script_name);
+  $uri->host($PAUSE::Config->{SERVER_NAME}) if $PAUSE::Config->{SERVER_NAME};
   $self->{MYURL} = $uri;
 }
 


### PR DESCRIPTION
... so that even when someone goes to http://pause.cpan.org, (s)he will go to https://pause.perl.org next. This should fix #213 