### PR TITLE
set correct realm so that previous LWP request is correctly handled

### DIFF
--- a/lib/PAUSE/Middleware/Auth/Basic.pm
+++ b/lib/PAUSE/Middleware/Auth/Basic.pm
@@ -5,7 +5,7 @@ use Plack::Request;
 use HTTP::Status qw(:constants);
 use pause_1999::authen_user;
 
-sub prepare_app {}
+sub prepare_app { shift->realm('PAUSE') }
 
 sub call {
     my($self, $env) = @_;


### PR DESCRIPTION
Sorry, I've forgotten to set PAUSE realm, and that's why $ua->creadential(<url>, 'PAUSE', <user>, <pass>) failed (but succeeded if no explicit realm is set).