### PR TITLE
don't index packages seen in example/demo directories

### DIFF
--- a/lib/PAUSE/dist.pm
+++ b/lib/PAUSE/dist.pm
@@ -772,7 +772,8 @@ sub filter_pms {
     # skip "local" - somebody shipped his carton setup!
     # skip 'perl5" - somebody shipped her local::lib!
     # skip 'fatlib' - somebody shipped their fatpack lib!
-    next if $inmf =~ m!^(?:x?t|inc|local|perl5|fatlib)/!;
+    # skip 'example', 'examples', 'eg', and 'demo' - demo usage of the module, not installed
+    next if $inmf =~ m!^(?:x?t|inc|local|perl5|fatlib|examples?|eg|demo)/!;
 
     if ($self->{META_CONTENT}){
       my $no_index = $self->{META_CONTENT}{no_index}


### PR DESCRIPTION
Hi Andreas,

This change means that PAUSE won't look in examples/, example/, eg/, or demo/ when looking for package statements.

This will help resolve a number of permissions conflicts, where people have demo classes called things like `testclass.pm`, `example.pm`, etc.

Neil