### PR TITLE
Check perms on package name case insensitively

### DIFF
--- a/lib/PAUSE/package.pm
+++ b/lib/PAUSE/package.pm
@@ -187,10 +187,13 @@ sub perm_check {
       return 1;           # P2.1, P3.0
   }
 
-  # is uploader authorized for this package? --> case sensitive
+  # is uploader authorized for this package?
+  # This used to be done case-sensitively, but now PAUSE needs to consider
+  # these case sensitively, thanks to CASE insensitive filesystems like on Windows
+  # and MacOS.
   my($is_primeur) = $dbh->selectrow_hashref(qq{SELECT package, userid
                                     FROM   primeur
-                                    WHERE  package = ? AND userid = ?},
+                                    WHERE  LOWER(package) = LOWER(?) AND userid = ?},
                                     undef,
                                     $package, $userid
                                   );


### PR DESCRIPTION
Right now, if someone else already has first-come on Foo::Bar,
then I can upload Foo::BAR, and as long as my version numbeer, then I'll get first-come on Foo::BAR,
permissions on both Foo::Bar and Foo::BAR will be listed in 06perms.txt,
but my module will be indexed.

This change checks permissions case insensitively, so I can't get perms on any case-variant of Foo::Bar

This addresses [issue 232](https://github.com/andk/pause/issues/232).

Cheers,
Neil