### PR TITLE
Update source-url in Perl 6 META6.json files when extracting

### DIFF
--- a/lib/PAUSE.pm
+++ b/lib/PAUSE.pm
@@ -146,6 +146,7 @@ $PAUSE::Config ||=
      PAUSE_LOG_DIR => $IS_PAUSE_US ? "/var/log" : "/home/k/PAUSE/log/",
      PAUSE_PUBLIC_DATA => '/home/ftp/pub/PAUSE/PAUSE-data',
      PML => 'ftp://pause.perl.org/pub/PAUSE/authors/id/',
+     PUB_MODULE_URL => 'http://www.cpan.org/authors/id/',
      RUNDATA => "/usr/local/apache/rundata/pause_1999",
      RUNTIME_MLDISTWATCH => 600, # 720 was the longest of on 2003-08-10,
                                  # 2004-12-xx we frequently see >20 minutes


### PR DESCRIPTION
The source-url field in the META6.json is used by installers to actually fetch the dist. Without this source-url, the installer has to guess the filename extension of the archive (which is what zef currently does). I fully expect installers to actually replace the first part of the URL with the base URL of a CPAN mirror. This has been agreed to by zef's author.

Please note that while I've tested the code in a separate test script, I have not tested it as part of PAUSE itself. It works in the test script and does compile in PAUSE, but it's possible that I have misunderstood what the contents of some of the variables or configuration values should be.

The server load should hardly be affected by this patch as the change only affects uploads of Perl 6 modules and anyway JSON::XS is very fast.