### PR TITLE
Fix updated source-url in Perl 6 META6.json files

### DIFF
--- a/lib/PAUSE/dist.pm
+++ b/lib/PAUSE/dist.pm
@@ -1085,7 +1085,7 @@ sub write_updated_meta6_json {
   }
   close $meta_fh;
 
-  $meta->{'source-url'} = $PAUSE::Config->{PUB_MODULE_URL} . "$MLROOT/$dist";
+  $meta->{'source-url'} = $PAUSE::Config->{PUB_MODULE_URL} . $dist;
 
   open $meta_fh, '>', "$MLROOT/$sans.meta"
     or $self->verbose(1,"Failed to open Perl 6 meta file for writing: $!");


### PR DESCRIPTION
Untested

Currently uploading a Perl6 distribution to cpan will result in a source-url such as:
http://www.cpan.org/authors/id//home/ftp/pub/PAUSE/authors/id/U/UG/UGEXE/Perl6/Text-Levenshtein-Damerau-0.1.7.tar.gz

Where the extra portion matches [$MLROOT](https://github.com/andk/pause/blob/259318c279d88b65ebfd36a8bd705a0fc00e48f6/lib/PAUSE.pm#L136) - however I am making the assumption that `$MLROOT` value is not modified.

@niner 