### PR TITLE
Set up signal handlers to use always Log::Dispatch::Config logger

### DIFF
--- a/app.psgi
+++ b/app.psgi
@@ -9,7 +9,7 @@ use Plack::Request;
 use Plack::App::Directory::Apaxy;
 use Log::Dispatch::Config;
 
-Log::Dispatch::Config->configure("etc/plack_log.conf.".($ENV{PLACK_ENV} // 'development'));
+Log::Dispatch::Config->configure("$FindBin::Bin/etc/plack_log.conf.".($ENV{PLACK_ENV} // 'development'));
 
 # preload stuff
 use pause_1999::config;
@@ -60,9 +60,7 @@ builder {
 
     # Static files should not be served by application server actually.
     # This is only for testing/developing.
-    enable 'Static',
-        path => qr{(?:(?<!index)\.(js|css|gif|jpg|png|pod|html)$|^/\.well-known/)},
-        root => "$FindBin::Bin/htdocs";
+    enable 'Static', path => qr{(?<!index)\.(js|css|gif|jpg|png|pod|html)$}, root => "$FindBin::Bin/htdocs";
 
     mount '/pub/PAUSE' => builder {
         enable '+PAUSE::Middleware::Auth::Basic';

--- a/etc/plack_log.conf.development
+++ b/etc/plack_log.conf.development
@@ -2,4 +2,4 @@ dispatchers = screen
 
 screen.class = Log::Dispatch::Screen
 screen.min_level = debug
-screen.format = [%d] [%p] %m at %F line %L%n
+screen.format = [%d{%Y-%m-%d %H:%M:%S}] [%p] %m%n

--- a/etc/plack_log.conf.production
+++ b/etc/plack_log.conf.production
@@ -4,4 +4,4 @@ file.class = Log::Dispatch::File
 file.min_level = debug
 file.filename = /var/log/PAUSE-httpd/access_log_plack
 file.mode = append
-file.format = [%d] [%p] %m at %F line %L%n
+file.format = [%d{%Y-%m-%d %H:%M:%S}] [%p] %m%n

--- a/lib/pause_1999/authen_user.pm
+++ b/lib/pause_1999/authen_user.pm
@@ -111,6 +111,22 @@ sub header {
 sub handler {
   my($req) = @_;
 
+  local $SIG{__WARN__} = sub {
+    my $message = shift;
+    Log::Dispatch::Config->instance->log(
+      level => 'warn',
+      message => $message,
+    );
+  };
+  local $SIG{__DIE__} = sub {
+    my $message = shift;
+    Log::Dispatch::Config->instance->log(
+      level => 'warn',
+      message => ref $message eq 'PAUSE::HeavyCGI::Exception' ? $message->{ERROR} : $message
+    );
+    Carp::croak $message;
+  };
+
   my $cookie;
   my $uri = $req->path || "";
   my $args = $req->uri->query;

--- a/lib/pause_1999/main.pm
+++ b/lib/pause_1999/main.pm
@@ -152,6 +152,21 @@ WillLast
 
 sub dispatch {
   my $self = shift;
+  local $SIG{__WARN__} = sub {
+    my $message = shift;
+    Log::Dispatch::Config->instance->log(
+      level   => 'warn',
+      message => $message,
+    );
+  };
+  local $SIG{__DIE__} = sub {
+    my $message = shift;
+    Log::Dispatch::Config->instance->log(
+      level   => 'error',
+      message => ref $message eq 'PAUSE::HeavyCGI::Exception' ? $message->{ERROR} : $message,
+    );
+    Carp::croak $message;
+  };
   $self->init;
   my $req = $self->{REQ};
   warn sprintf "DEBUG: uri[%s]location[%s]", $req->path, ''; # $r->location;


### PR DESCRIPTION
so that warns and dies have timestamps.