### PR TITLE
Use reCAPTCHA to validate new user requests

### DIFF
--- a/lib/PAUSE.pm
+++ b/lib/PAUSE.pm
@@ -163,6 +163,9 @@ $PAUSE::Config ||=
      MIN_MTIME_CHECKSUMS => 1300000000, # invent a threshold for oldest mtime
      HAVE_PERLBAL => 1,
      ZCAT_PATH  => (List::Util::first { -x $_ } ("/bin/zcat", "/usr/bin/zcat" )),
+     RECAPTCHA_ENABLED => 0,
+     RECAPTCHA_SITE_KEY => "",
+     RECAPTCHA_SECRET_KEY => "",
     };
 
 unless ($INC{"PrivatePAUSE.pm"}) { # reload within apache

--- a/lib/PAUSE.pm
+++ b/lib/PAUSE.pm
@@ -166,6 +166,7 @@ $PAUSE::Config ||=
      RECAPTCHA_ENABLED => 0,
      RECAPTCHA_SITE_KEY => "",
      RECAPTCHA_SECRET_KEY => "",
+     RECAPTCHA_DAILY_LIMIT => 100, # above this, revert to manual approval
     };
 
 unless ($INC{"PrivatePAUSE.pm"}) { # reload within apache

--- a/lib/pause_1999/edit.pm
+++ b/lib/pause_1999/edit.pm
@@ -2277,7 +2277,7 @@ sub scheduled {
 }
 
 sub add_user_doit {
-  my($self,$mgr,$userid,$fullname,$dont_clear) = @_;
+  my($self,$mgr,$userid,$fullname) = @_;
   my $req = $mgr->{REQ};
   my $T = time;
   my $dbh = $mgr->connect;
@@ -2423,12 +2423,10 @@ Subject: $subject\n};
     $blurb =~ s/\bCENSORED\b/$email/;
     $mgr->send_mail_multi([$email],$header,$blurb);
 
-    unless ($dont_clear) {
-      warn "Info: clearing all fields";
-      for my $field (qw(userid fullname email homepage subscribe memo)) {
+    warn "Info: clearing all fields";
+    for my $field (qw(userid fullname email homepage subscribe memo)) {
         my $param = "pause99_add_user_$field";
         $req->parameters->set($param,"");
-      }
     }
 
   } else {
@@ -2487,7 +2485,6 @@ sub add_user {
 
     $req->parameters->set("pause99_add_user_userid", $userid) if $userid;
     my $doit = 0;
-    my $dont_clear;
     my $fullname_raw = $req->param('pause99_add_user_fullname');
     my($fullname);
     $fullname = $mgr->any2utf8($fullname_raw);
@@ -2630,7 +2627,6 @@ sub add_user {
 	if (@urows) {
           my @rows = map { $_->{line} } sort { $b->{score} <=> $a->{score} } @urows;
 	  $doit = 0;
-	  $dont_clear = 1;
 	  unshift @rows, qq{
  <h3>Not submitting <i>$userid</i>, maybe we have a duplicate here</h3>
  <p>$s_package converted the fullname [<b>$fullname</b>] to [$s_code]</p>
@@ -2653,7 +2649,7 @@ sub add_user {
     }
     my $T = time;
     if ($doit) {
-      push @m, $self->add_user_doit($mgr,$userid,$fullname,$dont_clear);
+      push @m, $self->add_user_doit($mgr,$userid,$fullname);
     } elsif (@error) {
       push @m, qq{<h3>Error processing form</h3>};
       for (@error) {

--- a/lib/pause_1999/edit.pm
+++ b/lib/pause_1999/edit.pm
@@ -2384,39 +2384,7 @@ Description: };
                    qq{stered in authen_pause.$PAUSE::Config->{AUTHEN_USER_TABLE}</p>}]
                  ) unless $rc;
         $dbh->disconnect;
-        my $otpwblurb = qq{
-
-(This mail has been generated automatically by the Perl Authors Upload
-Server on behalf of the admin $PAUSE::Config->{ADMIN})
-
-As already described in a separate message, you\'re a registered Perl
-Author with the userid $userid. For the sake of approval I have
-assigned to you a change-password-only-password that enables
-you to pick your own password. This password is \"$onetime\"
-(without the enclosing quotes). Please visit
-
-  https://pause.perl.org/pause/authenquery?ACTION=change_passwd
-
-and use this password to initialize your account in the authentication
-database. Once you have entered your password there, your one-time
-password is expired automatically. If you cannot connect to the above
-URL, you can replace 'https' with 'http', but then you are not using
-SSL encryption. Be careful to always use an SSL connection if
-possible, otherwise your password can be intercepted by third parties.
-
-Thanks & Regards,
---
-$PAUSE::Config->{ADMIN}
-};
-
-        my $header = {
-                      Subject => $subject,
-                     };
-        warn "header[$header]otpwblurb[$otpwblurb]";
-        $mgr->send_mail_multi([$email,$PAUSE::Config->{ADMIN}],
-                              $header,
-                              $otpwblurb);
-
+        $self->_send_otp_email( $mgr, $userid, $email, $onetime );
       }
 
       @blurb = qq{
@@ -7384,6 +7352,41 @@ sub _verify_recaptcha {
     };
 
     return $ok, $err;
+}
+
+sub _send_otp_email {
+    my ( $self, $mgr, $userid, $email, $onetime ) = @_;
+
+    my $otpwblurb = <<"HERE";
+
+(This mail has been generated automatically by the Perl Authors Upload
+Server on behalf of the admin $PAUSE::Config->{ADMIN})
+
+As already described in a separate message, you\'re a registered Perl
+Author with the userid $userid. For the sake of approval I have
+assigned to you a change-password-only-password that enables
+you to pick your own password. This password is \"$onetime\"
+(without the enclosing quotes). Please visit
+
+  https://pause.perl.org/pause/authenquery?ACTION=change_passwd
+
+and use this password to initialize your account in the authentication
+database. Once you have entered your password there, your one-time
+password is expired automatically. If you cannot connect to the above
+URL, you can replace 'https' with 'http', but then you are not using
+SSL encryption. Be careful to always use an SSL connection if
+possible, otherwise your password can be intercepted by third parties.
+
+Thanks & Regards,
+--
+$PAUSE::Config->{ADMIN}
+HERE
+
+    my $header = {
+        Subject => qq{Welcome new user $userid}
+    };
+    warn "header[$header]otpwblurb[$otpwblurb]";
+    $mgr->send_mail_multi( [ $email, $PAUSE::Config->{ADMIN} ], $header, $otpwblurb );
 }
 
 1;

--- a/lib/pause_1999/edit.pm
+++ b/lib/pause_1999/edit.pm
@@ -2311,13 +2311,7 @@ sub add_user_doit {
 
   push @m, qq{<h3>Submitting query</h3>};
   if ($dbh->do($query,undef,@qbind)) {
-    push @m, sprintf(qq{<p>Query succeeded.</p><p>Do you want to }.
-                     qq{<a href="/pause/authenquery?pause99_add_m}.
-                     qq{od_userid=%s;SUBMIT_pause99_add_mod_previ}.
-                     qq{ew=preview">register a module for %s?</a></p>},
-                     $userid,
-                     $userid,
-                    );
+    push @m, qq{<p>New user creation succeeded.</p>};
     my(@blurb);
     my($subject);
     my $need_onetime = 0;

--- a/lib/pause_1999/edit.pm
+++ b/lib/pause_1999/edit.pm
@@ -2288,8 +2288,9 @@ sub add_user_doit {
   my($email) = $req->param('pause99_add_user_email');
   my($homepage) = $req->param('pause99_add_user_homepage');
   my $entered_by = $mgr->{User}{fullname};
+  my $is_mailing_list = $req->param('pause99_add_user_subscribe') gt '';
 
-  if ( $req->param('pause99_add_user_subscribe') gt '' ) {
+  if ( $is_mailing_list ) {
     $query = qq{INSERT INTO users (
                       userid,          isa_list,             introduced,
                       changed,         changedby)
@@ -2315,7 +2316,7 @@ sub add_user_doit {
     my(@blurb);
     my($subject);
     my $need_onetime = 0;
-    if ( $req->param('pause99_add_user_subscribe') gt '' ) {
+    if ( $is_mailing_list ) {
 
       # Add a mailinglist: INSERT INTO maillists
 

--- a/lib/pause_1999/edit.pm
+++ b/lib/pause_1999/edit.pm
@@ -2658,13 +2658,6 @@ sub add_user {
                        maxlength=>256),
        qq{<br />},
 
-       qq{<br />If you want to send a message to new author, please
-       enter it here:<br />},
-
-       $mgr->textarea(name=>"pause99_add_user_memo",
-                      rows=>6,
-                      cols=>60),
-       qq{<br />},
        $submit_butts,
        qq{<br />},
        $delete_link,


### PR DESCRIPTION
This PR will directly add users to the database if their request is validated
by reCAPTCHA.  The use of reCAPTCHA is feature-flagged, so can be enabled and
disabled at will.
