### PR TITLE
Extract primeur and perms SQL to permissions manager class

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -53,6 +53,7 @@ WriteMakefile(
     Mail::Send
     Module::Faker::Dist
     Module::Signature
+    Moo
     MooseX::StrictConstructor
     Net::FTP
     Parse::CPAN::Packages

--- a/lib/PAUSE/Permissions.pm
+++ b/lib/PAUSE/Permissions.pm
@@ -91,6 +91,25 @@ sub plan_set_first_come {
   };
 }
 
+# returns a callback to set comaint permissions on a package
+sub plan_set_comaint {
+  my ($self, $userid, $package) = @_;
+  my $dbh = $self->dbh;
+
+  return sub {
+    my $log_prefix = shift || "";
+    $log_prefix .= " " if length $log_prefix;
+    my $ret = eval { $dbh->do("INSERT INTO perms (package, userid) VALUES (?,?)", undef, $package, $userid) };
+    my $err = $@;
+    $ret //= "";
+    $self->verbose(1,
+                  "${log_prefix}Inserted into perms package[$package]userid[$userid]ret[$ret]".
+                  "err[$err]\n");
+    die $err if $err;
+    return 1;
+  };
+}
+
 sub userid_has_permissions_on_package {
   my ($self, $userid, $package) = @_;
 

--- a/lib/PAUSE/Permissions.pm
+++ b/lib/PAUSE/Permissions.pm
@@ -15,7 +15,16 @@ has dbh => (
 # returns first_come user for a package or the empty string
 sub get_package_first_come {
   my ($self, $pkg) = @_;
-  my $query = "qq{SELECT package, userid FROM primeur where LOWER(package) = LOWER(?)}";
+  my $query = "SELECT package, userid FROM primeur where LOWER(package) = LOWER(?)";
+  my $owner = $self->dbh->selectrow_arrayref($query, undef, $pkg);
+  return $owner->[1] if $owner;
+  return "";
+}
+
+# returns first_come user for a package or the empty string
+sub get_package_first_come_with_exact_case {
+  my ($self, $pkg) = @_;
+  my $query = "SELECT package, userid FROM primeur where package = ?";
   my $owner = $self->dbh->selectrow_arrayref($query, undef, $pkg);
   return $owner->[1] if $owner;
   return "";

--- a/lib/PAUSE/Permissions.pm
+++ b/lib/PAUSE/Permissions.pm
@@ -12,6 +12,15 @@ has dbh => (
   required => 1,
 );
 
+# returns first_come user for a package or the empty string
+sub get_package_first_come {
+  my ($self, $pkg) = @_;
+  my $query = "qq{SELECT package, userid FROM primeur where LOWER(package) = LOWER(?)}";
+  my $owner = $self->dbh->selectrow_arrayref($query, undef, $pkg);
+  return $owner->[1] if $owner;
+  return "";
+}
+
 # returns callback to copy permissions from one package to another;
 # currently doesn't address primeur or *remove* excess permissions from
 # the destination. I.e. after running this, perms on the destination will

--- a/lib/PAUSE/Permissions.pm
+++ b/lib/PAUSE/Permissions.pm
@@ -31,6 +31,21 @@ sub get_package_first_come_with_exact_case {
   return "";
 }
 
+sub get_package_maintainers_list_any_case {
+  my ($self, $package) = @_;
+  my $sql = qq{
+    SELECT package, userid
+      FROM   primeur
+      WHERE  LOWER(package) = LOWER(?)
+      UNION
+    SELECT package, userid
+      FROM   perms
+      WHERE  LOWER(package) = LOWER(?)
+  };
+  my @args = ($package) x 2;
+  return $self->dbh->selectall_arrayref($sql, undef, @args);
+}
+
 # returns callback to copy permissions from one package to another;
 # currently doesn't address primeur or *remove* excess permissions from
 # the destination. I.e. after running this, perms on the destination will

--- a/lib/PAUSE/Permissions.pm
+++ b/lib/PAUSE/Permissions.pm
@@ -74,6 +74,23 @@ sub plan_package_permission_copy {
   }
 }
 
+# returns a callback to set first_come permissions on a package
+sub plan_set_first_come {
+  my ($self, $userid, $package) = @_;
+  my $dbh = $self->dbh;
+
+  return sub {
+    my $ret = eval { $dbh->do("INSERT INTO primeur (package, userid) VALUES (?,?)", undef, $package, $userid) };
+    my $err = $@;
+    $ret //= "";
+    $self->verbose(1,
+                  "Inserted into primeur package[$package]userid[$userid]ret[$ret]".
+                  "err[$err]\n");
+    die $err if $err;
+    return 1;
+  };
+}
+
 sub userid_has_permissions_on_package {
   my ($self, $userid, $package) = @_;
 

--- a/lib/PAUSE/Permissions.pm
+++ b/lib/PAUSE/Permissions.pm
@@ -3,10 +3,49 @@ use strict;
 use warnings;
 
 package PAUSE::Permissions;
-# ABSTRACT: goes here
 
-use Class::Tiny qw/dbh/;
+use DBI;
+use Moo;
+use PAUSE ();
 
+has dbh => (
+  is => 'lazy',
+);
+
+sub _build_dbh {
+  my ($self) = @_;
+  return PAUSE::dbh("mod");
+}
+
+sub userid_has_permissions_on_package {
+  my ($self, $userid, $package) = @_;
+
+  if ($package eq 'perl') {
+    return PAUSE->user_has_pumpking_bit($userid);
+  }
+
+  my $dbh = $self->dbh;
+
+  my ($has_perms) = $dbh->selectrow_array(
+    qq{
+      SELECT COUNT(*) FROM perms
+      WHERE userid = ? AND LOWER(package) = LOWER(?)
+    },
+    undef,
+    $userid, $package,
+  );
+
+  my ($has_primary) = $dbh->selectrow_array(
+    qq{
+      SELECT COUNT(*) FROM primeur
+      WHERE userid = ? AND LOWER(package) = LOWER(?)
+    },
+    undef,
+    $userid, $package,
+  );
+
+  return($has_perms || $has_primary);
+}
 
 1;
 

--- a/lib/PAUSE/Permissions.pm
+++ b/lib/PAUSE/Permissions.pm
@@ -1,0 +1,17 @@
+use 5.008001;
+use strict;
+use warnings;
+
+package PAUSE::Permissions;
+# ABSTRACT: goes here
+
+use Class::Tiny qw/dbh/;
+
+
+1;
+
+# Local Variables:
+# mode: cperl
+# cperl-indent-level: 2
+# End:
+# vim: set ts=2 sts=2 sw=2 et tw=75:

--- a/lib/PAUSE/Permissions.pm
+++ b/lib/PAUSE/Permissions.pm
@@ -12,7 +12,8 @@ has dbh => (
   required => 1,
 );
 
-# returns first_come user for a package or the empty string
+# returns first_come user for a package or the empty string. If there are
+# more than one matches, only the first is returned
 sub get_package_first_come {
   my ($self, $pkg) = @_;
   my $query = "SELECT package, userid FROM primeur where LOWER(package) = LOWER(?)";

--- a/lib/PAUSE/Permissions.pm
+++ b/lib/PAUSE/Permissions.pm
@@ -14,7 +14,7 @@ has dbh => (
 
 # returns first_come user for a package or the empty string. If there are
 # more than one matches, only the first is returned
-sub get_package_first_come {
+sub get_package_first_come_any_case {
   my ($self, $pkg) = @_;
   my $query = "SELECT package, userid FROM primeur where LOWER(package) = LOWER(?)";
   my $owner = $self->dbh->selectrow_arrayref($query, undef, $pkg);

--- a/lib/PAUSE/Permissions.pm
+++ b/lib/PAUSE/Permissions.pm
@@ -102,6 +102,10 @@ sub plan_set_first_come {
 
   return sub {
     my $dbh = $self->dbh_callback->();
+
+    # ensure first-come also is in perms
+    $self->plan_set_comaint($userid, $package)->();
+
     # we disable errors so that the insert emulates an upsert
     local ( $dbh->{RaiseError} ) = 0;
     local ( $dbh->{PrintError} ) = 0;

--- a/lib/PAUSE/PermsManager.pm
+++ b/lib/PAUSE/PermsManager.pm
@@ -2,7 +2,7 @@ use 5.008001;
 use strict;
 use warnings;
 
-package PAUSE::Permissions;
+package PAUSE::PermsManager;
 
 use Moo;
 use PAUSE ();

--- a/lib/PAUSE/mldistwatch.pm
+++ b/lib/PAUSE/mldistwatch.pm
@@ -38,7 +38,7 @@ use PAUSE::pmfile ();
 use PAUSE::package ();
 use PAUSE::mldistwatch::Constants ();
 use PAUSE::MailAddress ();
-use PAUSE::Permissions ();
+use PAUSE::PermsManager ();
 use Safe;
 use Text::Format;
 
@@ -149,7 +149,7 @@ sub reindex {
 sub permissions {
     my $self = shift;
     return $self->{PERM_MGR} if $self->{PERM_MGR};
-    $self->{PERM_MGR} = PAUSE::Permissions->new( dbh_callback => sub { $self->connect } );
+    $self->{PERM_MGR} = PAUSE::PermsManager->new( dbh_callback => sub { $self->connect } );
 }
 
 sub rewrite_indexes {

--- a/lib/PAUSE/mldistwatch.pm
+++ b/lib/PAUSE/mldistwatch.pm
@@ -251,6 +251,7 @@ sub disconnect {
     my $self = shift;
     return unless $self->{DBH};
     $self->{DBH}->disconnect;
+    delete $self->{PERM_MGR};
     delete $self->{DBH};
 }
 

--- a/lib/PAUSE/mldistwatch.pm
+++ b/lib/PAUSE/mldistwatch.pm
@@ -149,7 +149,7 @@ sub reindex {
 sub permissions {
     my $self = shift;
     return $self->{PERM_MGR} if $self->{PERM_MGR};
-    $self->{PERM_MGR} = PAUSE::Permissions->new( dbh => $self->connect );
+    $self->{PERM_MGR} = PAUSE::Permissions->new( dbh_callback => sub { $self->connect } );
 }
 
 sub rewrite_indexes {

--- a/lib/PAUSE/package.pm
+++ b/lib/PAUSE/package.pm
@@ -202,7 +202,7 @@ sub perm_check {
           # seems ok: perl is always right
       } elsif (! (@owned && @owned_exact)) {
           # we must not index this and we have to inform somebody
-          my $owner = eval { PAUSE::owner_of_module($package, $dbh) }
+          my $owner = eval { $self->hub->permissions->get_package_first_come($package) }
                     // "unknown";
 
           my $not_owner = qq{Not indexed because permission missing.

--- a/lib/PAUSE/package.pm
+++ b/lib/PAUSE/package.pm
@@ -162,7 +162,7 @@ sub perm_check {
           # seems ok: perl is always right
       } elsif (! (@owned && @owned_exact)) {
           # we must not index this and we have to inform somebody
-          my $owner = eval { $self->hub->permissions->get_package_first_come($package) }
+          my $owner = eval { $self->hub->permissions->get_package_first_come_any_case($package) }
                     // "unknown";
 
           my $not_owner = qq{Not indexed because permission missing.
@@ -724,7 +724,7 @@ sub checkin_into_primeur {
       if(lc($self->{MAIN_PACKAGE}) eq lc($package)) {
           $userid = $self->{USERID} or die;
       } else {
-          $userid = $self->hub->permissions->get_package_first_come($self->{MAIN_PACKAGE});
+          $userid = $self->hub->permissions->get_package_first_come_any_case($self->{MAIN_PACKAGE});
           $userid = $self->{USERID} unless $userid;
           die unless $userid;
       }

--- a/lib/PAUSE/package.pm
+++ b/lib/PAUSE/package.pm
@@ -129,27 +129,6 @@ sub perm_check {
 
   my $plan_set_comaint = $self->hub->permissions->plan_set_comaint($userid, $package);
 
-  # package has any authorized maintainers? --> case insensitive
-
-  my $sql = qq{
-    SELECT package, userid
-    FROM   primeur
-    WHERE  LOWER(package) = LOWER(?)
-    UNION
-    SELECT package, userid
-    FROM   perms
-    WHERE  LOWER(package) = LOWER(?)
-    UNION
-    SELECT modid, userid
-    FROM   mods
-    WHERE  LOWER(modid) = LOWER(?)
-  };
-  my @args = ($package) x 3;
-  my($auth_ids) = $dbh->selectall_arrayref($sql,
-    undef,
-    @args
-  );
-
   if ($self->{FIO}{DIO} && PAUSE::isa_regular_perl($dist)) {
       $plan_set_comaint ->("(perl)");
       return 1;           # P2.1, P3.0
@@ -161,6 +140,8 @@ sub perm_check {
       $plan_set_comaint ->("(primeur)");
       return 1;           # P2.1, P3.0
   }
+
+  my $auth_ids = $self->hub->permissions->get_package_maintainers_list_any_case($package);
 
   if (@$auth_ids) {
 

--- a/lib/PAUSE/package.pm
+++ b/lib/PAUSE/package.pm
@@ -772,14 +772,14 @@ sub checkin_into_primeur {
           die unless $userid;
       }
   }
-  my $query = "INSERT INTO primeur (package, userid) VALUES (?,?)";
-  my $ret = $dbh->do($query, {}, $package, $userid);
-  my $err = "";
-  $err = $dbh->errstr unless defined $ret;
-  $ret ||= "";
-  $self->verbose(1,
-                  "Inserted into primeur package[$package]userid[$userid]ret[$ret]".
-                  "err[$err]\n");
+ 
+  my $plan = $self->hub->permissions->plan_set_first_come($userid, $package);
+  
+  # XXX Why do we discard errors here?  It was like that before the
+  # refactoring so this just continues that. -- xdg, 2018-04-22
+  eval { $plan->() };
+
+  return 1;
 }
 
 # package PAUSE::package;

--- a/lib/PAUSE/package.pm
+++ b/lib/PAUSE/package.pm
@@ -127,8 +127,7 @@ sub perm_check {
 
   my($userid) = $self->{USERID};
 
-  my $ins_perms = "INSERT INTO perms (package, userid) VALUES (?, ?)";
-  my @ins_params = ($package, $userid);
+  my $plan_set_comaint = $self->hub->permissions->plan_set_comaint($userid, $package);
 
   # package has any authorized maintainers? --> case insensitive
 
@@ -152,29 +151,18 @@ sub perm_check {
   );
 
   if ($self->{FIO}{DIO} && PAUSE::isa_regular_perl($dist)) {
-      local($dbh->{RaiseError}) = 0;
-      local($dbh->{PrintError}) = 0;
-      my $ret = $dbh->do($ins_perms, undef, @ins_params);
-      my $err = "";
-      $err = $dbh->errstr unless defined $ret;
-      $ret ||= "";
-      $self->verbose(1,"(primeur)ins_perms[$ins_perms/@ins_params]ret[$ret]err[$err]\n");
-
+      # XXX Why do we ignore errors?  This predated refactoring to use
+      # $set_comaint_plan. -- xdg, 2018-04-22
+      eval { $plan_set_comaint ->("(perl)") };
       return 1;           # P2.1, P3.0
   }
 
   # is uploader authorized for this package? --> case sensitive
   my $primeur = $self->hub->permissions->get_package_first_come_with_exact_case($package);
   if ($userid eq $primeur) {
-
-      local($dbh->{RaiseError}) = 0;
-      local($dbh->{PrintError}) = 0;
-      my $ret = $dbh->do($ins_perms, undef, @ins_params);
-      my $err = "";
-      $err = $dbh->errstr unless defined $ret;
-      $ret ||= "";
-      $self->verbose(1,"(primeur)ins_perms[$ins_perms/@ins_params]ret[$ret]err[$err]\n");
-
+      # XXX Why do we ignore errors?  This predated refactoring to use
+      # $set_comaint_plan. -- xdg, 2018-04-22
+      eval { $plan_set_comaint ->("(primeur)") };
       return 1;           # P2.1, P3.0
   }
 
@@ -233,12 +221,9 @@ owner[$owner]
 
       # package has no existence in perms yet, so this guy is OK
 
-      local($dbh->{RaiseError}) = 0;
-      my $ret = $dbh->do($ins_perms, undef, @ins_params);
-      my $err = "";
-      $err = $dbh->errstr unless defined $ret;
-      $ret ||= "";
-      $self->verbose(1,"Package is new: (uploader)ins_perms[$ins_perms/@ins_params]ret[$ret]err[$err]\n");
+      # XXX Why do we ignore errors?  This predated refactoring to use
+      # $set_comaint_plan. -- xdg, 2018-04-22
+      eval { $plan_set_comaint ->("(uploader)") };
 
   }
   $self->verbose(1,sprintf( # just for debugging

--- a/lib/PAUSE/package.pm
+++ b/lib/PAUSE/package.pm
@@ -164,13 +164,8 @@ sub perm_check {
   }
 
   # is uploader authorized for this package? --> case sensitive
-  my($is_primeur) = $dbh->selectrow_hashref(qq{SELECT package, userid
-                                    FROM   primeur
-                                    WHERE  package = ? AND userid = ?},
-                                    undef,
-                                    $package, $userid
-                                  );
-  if ($is_primeur) {
+  my $primeur = $self->hub->permissions->get_package_first_come_with_exact_case($package);
+  if ($userid eq $primeur) {
 
       local($dbh->{RaiseError}) = 0;
       local($dbh->{PrintError}) = 0;

--- a/lib/PAUSE/package.pm
+++ b/lib/PAUSE/package.pm
@@ -767,12 +767,7 @@ sub checkin_into_primeur {
       if(lc($self->{MAIN_PACKAGE}) eq lc($package)) {
           $userid = $self->{USERID} or die;
       } else {
-          my $lookup = "select userid from primeur where lower(package) = lower(?)";
-          my $user_ids = $dbh->selectall_arrayref($lookup, undef, $self->{MAIN_PACKAGE});
-          my ($row) = pop @$user_ids;
-          if($row) {
-              $userid = pop @$row;
-          }
+          $userid = $self->hub->permissions->get_package_first_come($self->{MAIN_PACKAGE});
           $userid = $self->{USERID} unless $userid;
           die unless $userid;
       }

--- a/lib/PAUSE/package.pm
+++ b/lib/PAUSE/package.pm
@@ -726,7 +726,7 @@ sub checkin_into_primeur {
       } else {
           $userid = $self->hub->permissions->get_package_first_come_any_case($self->{MAIN_PACKAGE});
           $userid = $self->{USERID} unless $userid;
-          die unless $userid;
+          die "Shouldn't reach here: userid unknown" unless $userid;
       }
   }
 

--- a/lib/PAUSE/package.pm
+++ b/lib/PAUSE/package.pm
@@ -86,8 +86,9 @@ sub alert {
 sub give_regdowner_perms {
   # This subroutine originally existed for interactions with the module list,
   # which was effectively made a non-feature years ago.  Its job now is to
-  # ensure that new packages are given the same permission as those given to
-  # the main package of the distribution being uploaded. -- rjbs, 2018-04-19
+  # ensure that new packages are given, at a minimum, the same permission as
+  # those given to the main package of the distribution being uploaded.
+  # -- rjbs, 2018-04-19
   my $self = shift;
   my $dbh = $self->connect;
   my $package = $self->{PACKAGE};
@@ -112,7 +113,7 @@ sub give_regdowner_perms {
   # TODO: correctly set first-come as well
 
   # TODO: return if they're already equal permissions -- rjbs, 2018-04-19
-  $self->verbose(1, "Making permissions for package[$package] match main_mackage[$main_package]");
+  $self->verbose(1, "Granting permissions of main_mackage[$main_package] to package[$package]");
 
   for my $row (@$existing_permissions)
   {

--- a/lib/PAUSE/package.pm
+++ b/lib/PAUSE/package.pm
@@ -151,18 +151,14 @@ sub perm_check {
   );
 
   if ($self->{FIO}{DIO} && PAUSE::isa_regular_perl($dist)) {
-      # XXX Why do we ignore errors?  This predated refactoring to use
-      # $set_comaint_plan. -- xdg, 2018-04-22
-      eval { $plan_set_comaint ->("(perl)") };
+      $plan_set_comaint ->("(perl)");
       return 1;           # P2.1, P3.0
   }
 
   # is uploader authorized for this package? --> case sensitive
   my $primeur = $self->hub->permissions->get_package_first_come_with_exact_case($package);
   if ($userid eq $primeur) {
-      # XXX Why do we ignore errors?  This predated refactoring to use
-      # $set_comaint_plan. -- xdg, 2018-04-22
-      eval { $plan_set_comaint ->("(primeur)") };
+      $plan_set_comaint ->("(primeur)");
       return 1;           # P2.1, P3.0
   }
 
@@ -221,9 +217,7 @@ owner[$owner]
 
       # package has no existence in perms yet, so this guy is OK
 
-      # XXX Why do we ignore errors?  This predated refactoring to use
-      # $set_comaint_plan. -- xdg, 2018-04-22
-      eval { $plan_set_comaint ->("(uploader)") };
+      $plan_set_comaint ->("(uploader)");
 
   }
   $self->verbose(1,sprintf( # just for debugging
@@ -737,9 +731,6 @@ sub checkin_into_primeur {
 
   # print ">>>>>>>>checkin_into_primeur not yet implemented<<<<<<<<\n";
 
-  local($dbh->{RaiseError}) = 0;
-  local($dbh->{PrintError}) = 0;
-
   my $userid;
   my $dio = $self->parent->parent;
   if (exists $dio->{META_CONTENT}{x_authority}) {
@@ -757,12 +748,9 @@ sub checkin_into_primeur {
           die unless $userid;
       }
   }
- 
+
   my $plan = $self->hub->permissions->plan_set_first_come($userid, $package);
-  
-  # XXX Why do we discard errors here?  It was like that before the
-  # refactoring so this just continues that. -- xdg, 2018-04-22
-  eval { $plan->() };
+  $plan->();
 
   return 1;
 }

--- a/t/mldistwatch-db.t
+++ b/t/mldistwatch-db.t
@@ -21,7 +21,7 @@ subtest "retry indexing on db failure" => sub {
   local $PAUSE::Config->{PRE_DB_WORK_CALLBACK} = sub {
     state $x = 1;
     if ($x) {
-      $x--, die "dying for diagnostic purposes (x eq $x)\n";
+      $x--, die PAUSE::DBError->new("dying for diagnostic purposes (x eq $x)\n");
     }
   };
 
@@ -43,7 +43,7 @@ subtest "retry indexing on db failure, only three times" => sub {
   my $x = 0;
   local $PAUSE::Config->{PRE_DB_WORK_CALLBACK} = sub {
     $x++;
-    die "dying for diagnostic purposes (failure $x)\n";
+    die PAUSE::DBError->new("dying for diagnostic purposes (failure $x)\n");
   };
 
   my $result = $pause->test_reindex;


### PR DESCRIPTION
These commits pull all SQL that affects user permissions to a separate class.  Eventually, we hope to extend this to the web-side as well, but for now, it simplifies things for the mldistwatch side, including the case-conflict code that Rik is working on.