### PR TITLE
Link to the PAUSE operating model in 04pause

### DIFF
--- a/htdocs/04pause.html
+++ b/htdocs/04pause.html
@@ -175,7 +175,9 @@ validating and indexing uploads.  PAUSE unwraps the upload and scans the source 
 (namely all <code>*.pm</code> files) for package declarations.  In order for
 a module to be indexed, the submitting author must be the owner or an authorized
 maintainer for every package namespace found (unless the namespace is new, in
-which case the uploading author becomes the owner of it).
+which case the uploading author becomes the owner of it). More details about
+permissions and the indexing process are available in the
+<a href="https://github.com/andk/pause/blob/master/doc/operating-model.md">PAUSE Operating Model</a>.
 </p>
 
 <p>


### PR DESCRIPTION
Many authors see 04pause when considering uploading modules for the first time, and the PAUSE operating model contains lots of important information regarding indexing permissions.