### PR TITLE
Add a file to add distname column to perms table

### DIFF
--- a/one-off-utils/schemachange-2019-04-25.sql
+++ b/one-off-utils/schemachange-2019-04-25.sql
@@ -1,0 +1,2 @@
+alter table packages add distname varchar(128) not null default '' after dist;
+create index distname on packages (distname);


### PR DESCRIPTION
I'd like to have a new column called ```distname``` to implement permission manipulation per distribution that only holds a name part of the current ```dist``` column.