### PR TITLE
Replace generated numeric ids with more human friendly ids generated from the header text

### DIFF
--- a/lib/pause_2017/PAUSE/Web/Plugin/ServePauseDoc.pm
+++ b/lib/pause_2017/PAUSE/Web/Plugin/ServePauseDoc.pm
@@ -23,6 +23,7 @@ sub _serve_pause_doc {
     if ($name =~ /\.md$/) {
       require Text::Markdown::Hoedown;
       $html = Text::Markdown::Hoedown::markdown($html);
+      $html =~ s!<h([1-6]) id="toc_([0-9]+)">(.*?)</h\1>!qq{<h$1 id="} . _toc($2, $3) . qq{">$3</h$1>}!ge;
     }
     last;
   }
@@ -39,6 +40,14 @@ sub _serve_pause_doc {
 
   $c->stash(".pause")->{doc} = $html;
   $c->render("pause_doc");
+}
+
+sub _toc {
+  my ($num, $text) = @_;
+  $text = lc $text;
+  $text =~ s/[^a-z0-9_]+/_/g;
+  $text =~ s/(^_+|_+$)//g;
+  $text;
 }
 
 1;


### PR DESCRIPTION
That replaces toc_1, toc_2 ... in ```<h3 id="...">...</h3>``` with the_pause_operating_model, version_2, 1_background and so on, to make it easier to create a link for PAUSE Operating Model document.