### PR TITLE
when owner uploads a re-cased version of a package, update things

### DIFF
--- a/corpus/case-fakes/Foo-Bar-001.yaml
+++ b/corpus/case-fakes/Foo-Bar-001.yaml
@@ -1,0 +1,8 @@
+name: Foo-Bar
+version: 0.001
+provides:
+  Foo::Bar:
+   version: 0.001
+   file: lib/Foo/Bar.pm
+X_Module_Faker:
+  cpan_author: FCOME

--- a/corpus/case-fakes/Foo-Bar-002.yaml
+++ b/corpus/case-fakes/Foo-Bar-002.yaml
@@ -1,0 +1,8 @@
+name: Foo-Bar
+version: 0.002
+provides:
+  foo::bar:
+   version: 0.002
+   file: lib/foo/bar.pm
+X_Module_Faker:
+  cpan_author: FCOME

--- a/lib/PAUSE/PermsManager.pm
+++ b/lib/PAUSE/PermsManager.pm
@@ -223,7 +223,7 @@ sub canonicalize_module_casing {
       UPDATE packages SET package = ? WHERE LOWER(package) = LOWER(?);
     },
     undef,
-    ($package) x 6,
+    ($package) x 2,
   );
 
   return;

--- a/lib/PAUSE/dist.pm
+++ b/lib/PAUSE/dist.pm
@@ -40,6 +40,26 @@ sub ignoredist {
   return;
 }
 
+sub normalize_package_casing {
+  my ($self) = @_;
+
+  for my $lc_package (keys %{ $self->{CHECKINS} }) {
+    my %pkg_checkins = %{ $self->{CHECKINS}{$lc_package} };
+
+    my (@forms) = sort keys %pkg_checkins;
+
+    if (@forms == 1) {
+      $self->verbose(1, "Ensuring canonicalized case of $forms[0]");
+      $self->hub->permissions->canonicalize_module_casing($forms[0]);
+      return;
+    }
+
+    $self->verbose(1, "Case conflict resolved by LAST-RESORT: [@forms] -> $forms[0]");
+    my $form = $forms[0];
+    $self->hub->permissions->canonicalize_module_casing($forms[0]);
+  }
+}
+
 sub delete_goner {
   my $self = shift;
   my $dist = $self->{DIST};

--- a/lib/PAUSE/mldistwatch.pm
+++ b/lib/PAUSE/mldistwatch.pm
@@ -371,6 +371,8 @@ sub _do_the_database_work {
       $dbh->rollback;
     }
 
+    $dio->normalize_package_casing;
+
     return 1;
   };
 

--- a/t/mldistwatch-misc.t
+++ b/t/mldistwatch-misc.t
@@ -337,6 +337,59 @@ subtest "check overlong versions" => sub {
   );
 };
 
+subtest "case-changing imports" => sub {
+  my $pause = PAUSE::TestPAUSE->init_new;
+
+  $pause->add_first_come(FCOME  => 'Foo::Bar');
+  $pause->add_comaint(   CMAINT => 'Foo::Bar');
+
+  subtest "first step: initial upload" => sub {
+    {
+      $pause->upload_author_fake(FCOME => {
+        name    => 'Foo-Bar',
+        version => '0.001',
+        packages => [ 'Foo::Bar' ],
+      });
+
+      my $result = $pause->test_reindex;
+
+      # my $pkgs = $result->packages_data;
+      # my @rows = map {; [ $_->package, $_->version ] } $pkgs->packages;
+      # diag explain(\@rows);
+
+      $result->package_list_ok(
+        [ { package => 'Foo::Bar', version => '0.001'  } ],
+      );
+
+      $result->perm_list_ok(
+        {
+          'Foo::Bar' => { f => 'FCOME', c => ['CMAINT'] },
+        }
+      );
+    }
+
+    {
+      $pause->upload_author_fake(FCOME => {
+        name    => 'Foo-Bar',
+        version => '0.002',
+        packages => [ 'foo::bar' ],
+      });
+
+      my $result = $pause->test_reindex;
+
+      $result->package_list_ok(
+        [ { package => 'foo::bar', version => '0.002'  } ],
+      );
+
+      $result->perm_list_ok(
+        {
+          'foo::bar' => { f => 'FCOME', c => ['CMAINT'] },
+        }
+      );
+    }
+  };
+};
+
 subtest "check perl6 distribution indexing" => sub {
   my $pause = PAUSE::TestPAUSE->init_new;
   $pause->import_author_root('corpus/mld/perl6/authors');

--- a/t/mldistwatch-misc.t
+++ b/t/mldistwatch-misc.t
@@ -353,19 +353,13 @@ subtest "case-changing imports" => sub {
 
       my $result = $pause->test_reindex;
 
-      # my $pkgs = $result->packages_data;
-      # my @rows = map {; [ $_->package, $_->version ] } $pkgs->packages;
-      # diag explain(\@rows);
+      $result->package_list_ok([
+        { package => 'Foo::Bar', version => '0.001'  }
+      ]);
 
-      $result->package_list_ok(
-        [ { package => 'Foo::Bar', version => '0.001'  } ],
-      );
-
-      $result->perm_list_ok(
-        {
-          'Foo::Bar' => { f => 'FCOME', c => ['CMAINT'] },
-        }
-      );
+      $result->perm_list_ok({
+        'Foo::Bar' => { f => 'FCOME', c => ['CMAINT'] },
+      });
     }
 
     {
@@ -377,15 +371,13 @@ subtest "case-changing imports" => sub {
 
       my $result = $pause->test_reindex;
 
-      $result->package_list_ok(
-        [ { package => 'foo::bar', version => '0.002'  } ],
-      );
+      $result->package_list_ok([
+        { package => 'foo::bar', version => '0.002'  }
+      ]);
 
-      $result->perm_list_ok(
-        {
-          'foo::bar' => { f => 'FCOME', c => ['CMAINT'] },
-        }
-      );
+      $result->perm_list_ok({
+        'foo::bar' => { f => 'FCOME', c => ['CMAINT'] },
+      });
     }
   };
 };


### PR DESCRIPTION
When someone with permissions to update Foo::Bar uploads foo::bar, we now update all references to Foo::Bar to refer to foo::bar.