### PR TITLE
indexer: treat explicit provides/version as undef, but warn

### DIFF
--- a/lib/PAUSE/pmfile.pm
+++ b/lib/PAUSE/pmfile.pm
@@ -263,7 +263,7 @@ sub packages_per_pmfile {
                 if ($self->version_from_meta_ok) {
                     my $provides = $self->{DIO}{META_CONTENT}{provides};
                     if (exists $provides->{$pkg}) {
-                        if (exists $provides->{$pkg}{version}) {
+                        if (defined $provides->{$pkg}{version}) {
                             my $v = $provides->{$pkg}{version};
                             if ($v =~ /[_\s]/){   # ignore developer releases and "You suck!"
                                 next PLINE;
@@ -276,6 +276,9 @@ sub packages_per_pmfile {
                             }
                             $ppp->{$pkg}{version} = $version;
                         } else {
+                            if (exists $provides->{$pkg}) {
+                                $Logger->log("spec violation: meta provides for $pkg has an explicit undef");
+                            }
                             $ppp->{$pkg}{version} = "undef";
                         }
                     }


### PR DESCRIPTION
This is an updated version of https://github.com/andk/pause/pull/68

Rejecting this for spec violation isn't trivial right now, but I support doing it in the future.  For now, this just avoids a perl warning and adds a PAUSE warning.