### PR TITLE
Remove a note on fetching tarball from GitHub

### DIFF
--- a/lib/pause_2017/templates/user/uri/add.html.ep
+++ b/lib/pause_2017/templates/user/uri/add.html.ep
@@ -57,12 +57,7 @@ you do not seem to want HTTP upload enabled, we do
 
 <p class="url_upload"><b>GET URL:</b> PAUSE fetches
 any http or ftp URL that can be handled by LWP: use the text
-field (please specify the <i>complete URL</i>). How to use this
-for direct publishing from your github repository has been
-described by Mike Schilli in the historical posting
-http://blog.usarundbrief.com/?p=36 but it is not available on
-the net anymore. If you find a copy, please let us
-know.</p>
+field (please specify the <i>complete URL</i>).</p>
 
 <blockquote><b>Please,</b> make sure your filename
 contains a version number. For security reasons you will never


### PR DESCRIPTION
as the article is already gone for years and the practice is error prone.
re #259, #183 