### PR TITLE
remove remaining search.cpan.org usage in documentation

### DIFF
--- a/htdocs/04pause.html
+++ b/htdocs/04pause.html
@@ -137,8 +137,7 @@ on CPAN and understand (from the name alone) what it does.
 Likewise, there are so many modules already on CPAN that it's a good idea
 to be sure that your module is doing something new or at least different
 (and hopefully better) than something already on CPAN.  Search for similar
-modules on <a href="http://metacpan.org">metacpan.org</a> or
-<a href="http://search.cpan.org/">search.cpan.org</a>.
+modules on <a href="https://metacpan.org">metacpan.org</a>.
 </p>
 
 <blockquote>
@@ -204,17 +203,15 @@ minutes later an email about the indexing process.
 </p>
 
 <p>
-CPAN search engines like <a href="http://metacpan.org">metacpan.org</a> and
-<a href="http://search.cpan.org/">search.cpan.org</a> use these indexes
-and other heuristics to allow Perl developers to find modules that
-interest them.
+CPAN search engines like <a href="https://metacpan.org">metacpan.org</a>
+use these indexes and other heuristics to allow Perl developers to find
+modules that interest them.
 </p>
 
 <p>If you have questions about these, be sure to send them to the right place:</p>
 
 <ul>
     <li>PAUSE and CPAN mirroring: modules@perl.org</li>
-    <li>search.cpan.org: cpansearch@perl.org</li>
     <li>metacpan.org:  Submit questions via the <a href="https://github.com/CPAN-API/metacpan-web/issues">metacpan bug tracker</a></li>
 </ul>
 
@@ -282,7 +279,7 @@ steps and remember to be respectful all along:</p>
 
 <li>Try to reach the author via mail. At the very least, try
    PAUSE_ID@cpan.org, any mail address the author listed on his
-   search.cpan.org/~PAUSE_ID page, and any mail address that's listed
+   metacpan.org/author/PAUSE_ID page, and any mail address that's listed
    in his or her module documentation. If there's even a mailing list,
    don't forget that either.</li>
 
@@ -389,7 +386,7 @@ dangerous things within that line.</p>
 
 <p>Before you decide which style of versioning you prefer, you might
 want to read the <a
-href="http://search.cpan.org/perldoc?version">version</a> manpage.</p>
+href="https://metacpan.org/pod/version">version</a> manpage.</p>
 
 <h3><a id="developerreleases" name="developerreleases">Developer Releases</a></h3>
 

--- a/lib/pause_1999/edit.pm
+++ b/lib/pause_1999/edit.pm
@@ -1594,7 +1594,7 @@ filename[%s]. </p>
       topmost README file as, say, Foo-Bar-3.14.readme into your
       directory. <b>Hint:</b> if you're looking for an even more
       convenient way to upload files than this form, you can try the
-      <a href="http://search.cpan.org/dist/cpan-upload-http/">cpan-upload-http</a> script.
+      <a href="https://metacpan.org/release/CPAN-Uploader">cpan-upload</a> script.
       </p>
 
 }; #};

--- a/lib/pause_2017/templates/user/uri/add.html.ep
+++ b/lib/pause_2017/templates/user/uri/add.html.ep
@@ -70,7 +70,7 @@ only) within a few hours after uploading and will put the
 topmost README file as, say, Foo-Bar-3.14.readme into your
 directory. <b>Hint:</b> if you're looking for an even more
 convenient way to upload files than this form, you can try the
-<a href="http://search.cpan.org/dist/cpan-upload-http/">cpan-upload-http</a> script.
+<a href="https://metacpan.org/release/CPAN-Uploader">cpan-upload</a> script.
 </p>
 
 <h3>Target Directory</h3><p> If you want to load the


### PR DESCRIPTION
No need to mention search.cpan.org anymore. Also I could not find the mentioned 'cpan-upload-http' script, so changed the references to CPAN-Uploader's cpan-upload script.