### PR TITLE
Fix travis issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: perl
 perl:
   - "5.16"

--- a/app_2017.psgi
+++ b/app_2017.psgi
@@ -7,9 +7,9 @@ use lib "$FindBin::Bin/lib/", "$FindBin::Bin/lib/pause_2017", "$FindBin::Bin/../
 use Plack::Builder;
 use Plack::App::Directory::Apaxy;
 use Path::Tiny;
-Log::Dispatch::Config->configure("$FindBin::Bin/etc/plack_log.conf.".($ENV{PLACK_ENV} // 'development'));
-
 my $AppRoot = path(__FILE__)->parent->realpath;
+Log::Dispatch::Config->configure("$AppRoot/etc/plack_log.conf.".($ENV{PLACK_ENV} // 'development'));
+
 $ENV{MOJO_REVERSE_PROXY} = 1;
 $ENV{MOJO_HOME} = $AppRoot;
 


### PR DESCRIPTION
Since sometime after the PTS 2019, Travis CI seemed to have changed the default testing environemnt and dropped support of older perls, and made our checks red. cf https://travis-ci.community/t/failure-with-perl-5-16-5-18-5-20/2458 and https://travis-ci.org/andk/pause/builds

With the first commit of this PR, I explicitly made Travis CI to use trusty to test, and with the second, I fixed app_2017.psgi to find etc/plack_log.conf.travis correctly while testing, to silence warnings.
 