### PR TITLE
update reference from module list to CPAN search

### DIFF
--- a/htdocs/00modlist.long.html
+++ b/htdocs/00modlist.long.html
@@ -9,8 +9,7 @@ This Perl 5 Registered Module List <i>document</i> is currently <i>not being mai
 and is several years out of date.<p>
 
 You can search current information on all modules at
-<a href="http://kobesearch.cpan.org/">kobesearch.cpan.org</a> and
-<a href="http://search.cpan.org/">search.cpan.org</a>.
+<a href="https://metacpan.org/">metacpan.org</a>.
 
 <p>The CPAN ("Comprehensive Perl Archive Network")
 global file archive that underlies these services can be directly accessed at


### PR DESCRIPTION
I seem to have missed this in #337, to redirect people to metacpan and not two search sites that no longer exist. There are a ton of search.cpan.org links lower on the page but I don't think it's worth bothering with any of the content of this page anymore, and the redirects should still work for them.