### PR TITLE
Tests and proposed fix for #348, where first-come can be lost

### DIFF
--- a/t/losing-first-come.t
+++ b/t/losing-first-come.t
@@ -1,0 +1,142 @@
+#
+# losing-first-come.t
+#
+# This test was written to demonstrate a bug that is causing authors
+# to lose a first-come permission, in a particular setup and release scenario.
+#
+# Setup:
+#   user FORD has first-come on package Guide (but an entry in `primeur` only)
+#   user ARTHUR has co-maint on package Guide (an entry in `perms`)
+#
+# First-come does a release, then co-maint does a release
+#   0. Setup as above
+#   1. FORD does a release, and afterwards both permissions are still present
+#   2. ARTHUR then does a release, and the perms are still present as well
+#
+# Co-maint does the first release
+#   3. Setup as above
+#   4. ARTHUR does a release. The bug is that the entry in `primeur` gets lost
+#   
+#
+use strict;
+use warnings;
+
+use 5.10.1;
+use lib 't/lib';
+use lib 't/privatelib';    # Stub PrivatePAUSE
+
+use Email::Sender::Transport::Test;
+$ENV{EMAIL_SENDER_TRANSPORT} = 'Test';
+
+use DBI;
+use File::Spec;
+use PAUSE;
+use PAUSE::TestPAUSE;
+
+use Test::More;
+
+# Set up permissions
+
+my $pause = PAUSE::TestPAUSE->init_new;
+
+add_to_primeur($pause, "FORD" => "Guide");
+$pause->add_comaint("ARTHUR" => "Guide");
+
+# First the person with first-come does a release
+
+$pause->upload_author_fake(
+    FORD => {
+        name => "Guide",
+        version => 0.001,
+        packages => [
+            Guide => { in_file => "lib/Guide.pm" }
+        ]
+    }
+);
+
+my $result = $pause->test_reindex;
+
+$result->package_list_ok([
+    { package => 'Guide', version => '0.001' },
+]);
+
+$result->perm_list_ok(
+    {
+        Guide => { f => "FORD", c => ["ARTHUR"] }
+    }
+);
+
+# Now the co-maint does the next release.
+$pause->upload_author_fake(
+    ARTHUR => {
+        name => "Guide",
+        version => 0.002,
+        packages => [
+            Guide => { in_file => "lib/Guide.pm" }
+        ]
+    }
+);
+
+$result = $pause->test_reindex;
+
+$result->package_list_ok([
+    { package => 'Guide', version => '0.002' },
+]);
+
+$result->perm_list_ok(
+    {
+        Guide => { f => "FORD", c => ["ARTHUR"] }
+    }
+);
+
+
+$pause = PAUSE::TestPAUSE->init_new;
+
+add_to_primeur($pause, "FORD" => "Guide");
+$pause->add_comaint("ARTHUR" => "Guide");
+
+# This time the co-maint does the first release
+$pause->upload_author_fake(
+    ARTHUR => {
+        name => "Guide",
+        version => 0.001,
+        packages => [
+            Guide => { in_file => "lib/Guide.pm" }
+        ]
+    }
+);
+
+$result = $pause->test_reindex;
+
+$result->package_list_ok([
+    { package => 'Guide', version => '0.001' },
+]);
+
+$result->perm_list_ok(
+    {
+        Guide => { f => "FORD", c => ["ARTHUR"] }
+    }
+);
+
+done_testing();
+
+# PAUSE::TestPAUSE has add_first_come() and add_comaint() methods.
+# This function is like one of those methods, but an odd one.
+# A first-come permission is really indicated by the author having
+# an entry in both the primeur and perms tables.
+# But for this test I want to check what happens when someone has
+# an entry for a package in primeur only.
+sub add_to_primeur
+{
+    my ($pause, $author, $package) = @_;
+
+    my $db_file = File::Spec->catfile( $pause->db_root, 'mod.sqlite' );
+    my $db      = DBI->connect( "dbi:SQLite:dbname=$db_file", undef, undef)
+                  or die "can't connect to db at $db_file: $DBI::errstr";
+
+    $db->do("INSERT INTO primeur (userid, package) VALUES (?, ?);",
+            undef, $author, $package)
+        or die "couldn't add to primeur for $author/$package: $DBI::errstr\n";
+
+}
+

--- a/t/propagating-permissions.t
+++ b/t/propagating-permissions.t
@@ -1,0 +1,129 @@
+#
+# propagating-permissions.t
+#
+# This tests that permissions on the lead package are
+# propagated to everyone who has permissions on that
+# package, regardless of who does the release
+#
+use strict;
+use warnings;
+
+use 5.10.1;
+use lib 't/lib';
+use lib 't/privatelib';    # Stub PrivatePAUSE
+
+use Email::Sender::Transport::Test;
+$ENV{EMAIL_SENDER_TRANSPORT} = 'Test';
+
+use DBI;
+use File::Spec;
+use PAUSE;
+use PAUSE::TestPAUSE;
+
+use Test::More;
+
+# Set up permissions
+
+my $pause = PAUSE::TestPAUSE->init_new;
+
+# First the person with first-come does a release
+
+$pause->upload_author_fake(
+    BILBO => {
+        name => "Hobbit",
+        version => 0.001,
+        packages => [
+            Hobbit => { in_file => "lib/Hobbit.pm" }
+        ]
+    }
+);
+
+my $result = $pause->test_reindex;
+
+$result->package_list_ok([
+    { package => 'Hobbit', version => '0.001' },
+]);
+
+$result->perm_list_ok(
+    {
+        Hobbit => { f => "BILBO" }
+    }
+);
+
+# BILBO gives co-maint to FRODO
+$pause->add_comaint("FRODO" => "Hobbit");
+
+$result = $pause->test_reindex;
+
+$result->package_list_ok([
+    { package => 'Hobbit', version => '0.001' },
+]);
+
+$result->perm_list_ok(
+    {
+        Hobbit => { f => "BILBO", c => ["FRODO"] }
+    }
+);
+
+# Then BILBO does another release that adds a second package
+# BILBO should get first-come on that, FRODO should get co-maint
+
+$pause->upload_author_fake(
+    BILBO => {
+        name => "Hobbit",
+        version => 0.002,
+        packages => [
+            Breakfast => { in_file => "lib/Breakfast.pm" },
+            Hobbit    => { in_file => "lib/Hobbit.pm" },
+        ]
+    }
+);
+
+$result = $pause->test_reindex;
+
+$result->package_list_ok([
+    { package => 'Breakfast', version => '0.002' },
+    { package => 'Hobbit', version => '0.002' },
+]);
+
+$result->perm_list_ok(
+    {
+        Breakfast => { f => "BILBO", c => ["FRODO"] },
+        Hobbit    => { f => "BILBO", c => ["FRODO"] },
+    }
+);
+
+# Now FRODO does a release, and he adds a package.
+# He should co-maint on the new package, and BILBO
+# should get the first come
+
+$pause->upload_author_fake(
+    FRODO => {
+        name => "Hobbit",
+        version => 0.003,
+        packages => [
+            Breakfast => { in_file => "lib/Breakfast.pm" },
+            Hobbit    => { in_file => "lib/Hobbit.pm" },
+            Sting     => { in_file => "lib/Sting.pm" },
+        ]
+    }
+);
+
+$result = $pause->test_reindex;
+
+$result->package_list_ok([
+    { package => 'Breakfast', version => '0.003' },
+    { package => 'Hobbit',    version => '0.003' },
+    { package => 'Sting',     version => '0.003' },
+]);
+
+$result->perm_list_ok(
+    {
+        Breakfast => { f => "BILBO", c => ["FRODO"] },
+        Hobbit    => { f => "BILBO", c => ["FRODO"] },
+        Sting     => { f => "BILBO", c => ["FRODO"] },
+    }
+);
+
+done_testing();
+


### PR DESCRIPTION
This is my proposed fix for #348:

If a package has one author with first-come on a package
(but only with an entry in primeur, not in perms),
and someone else has co-maint (entry in perms).
If the co-maint does the next release, then the entry in primeur
is getting deleted, so it ends up with no first-come.

I added test `t/losing-first-come.t` which failed until canonicalize_module_casing() in `PAUSE::PermsManager`
was fixed.
I added another test `t/propagating-permissions.t`, which explicitly tests the expected behaviour
on propagating the permissions on the lead package to other packages, regardless of who releases.
This was so there was additional testing on the fix I made.

Notes: the mldistwatch-* and other tests all pass, though the ones that require Test::mysqld were skipped, as I don't have MySQL installed. Shout if you want me to do that.

I think @andk, @charsbar, and @rjbs should review the proposed change, as I'm not familiar enough with all the assumptions that might be made elsewhere, with respect to `primeur` and `perms`.