### PR TITLE
standardize how emails are signed

### DIFF
--- a/lib/pause_1999/edit.pm
+++ b/lib/pause_1999/edit.pm
@@ -16,7 +16,7 @@ eval {require Time::Duration};
 our $HAVE_TIME_DURATION = !$@;
 
 our $Valid_Userid = qr/^[A-Z]{3,9}$/;
-our $Yours = "Thanks,\n-- \nThe PAUSE\n";
+our $Yours = "Thanks,\n-- \nThe PAUSE Team\n";
 
 use utf8; # must be after the qr// for perl-5.6.1
 
@@ -1699,7 +1699,7 @@ into $her directory. The request used the following parameters:});
     }
     $mailblurb .= "\n";
     $mailblurb .= $self->wrappar($success);
-    $mailblurb .= "\n\nThanks for your contribution,\n-- \nThe PAUSE\n";
+    $mailblurb .= "\n\nThanks for your contribution,\n-- \nThe PAUSE Team\n";
 #    my $header = {
 #		  To => qq{$PAUSE::Config->{ADMIN}, $u->{email}, $mgr->{User}{email}},
 #		  Subject => qq{Notification from PAUSE},
@@ -4399,7 +4399,7 @@ PAUSE. See https://$server/pause/authenquery?ACTION=edit_mod
 
 Thanks for registering,
 -- 
-The PAUSE
+The PAUSE Team
 };
 
     my($blurb) = join "", @blurb;
@@ -4961,7 +4961,7 @@ $ml_entry
 
 Thanks for registering,
 -- 
-The PAUSE
+The PAUSE Team
 
 PS: The following links are only valid for module list maintainers:
 

--- a/lib/pause_1999/edit.pm
+++ b/lib/pause_1999/edit.pm
@@ -918,7 +918,7 @@ Data were entered by $mgr->{User}{userid} ($mgr->{User}{fullname}).
 Please check if they are correct.
 
 Thanks,
-The Pause
+The PAUSE Team
 };
 	# warn "sql[$sql]mailblurb[$mailblurb]";
 	# die;
@@ -1320,7 +1320,7 @@ No action is required, but it would be a good idea if somebody
 would check the correctness of the new password.
 
 Thanks,
-The Pause
+The PAUSE Team
 },
                                   $mgr->{User}->{userid},
                                   $mgr->{User}{fullname}||"fullname N/A",
@@ -2107,7 +2107,7 @@ http://%s/pause/authenquery?ACTION=delete_files
     push @blurb, $blurb;
     push @blurb, scalar $tf->format(qq{Note: to encourage deletions, all of past CPAN
 glory is collected on http://history.perl.org/backpan/});
-    push @blurb, qq{The Pause};
+    push @blurb, qq{The PAUSE Team};
     # $blurb = Text::Format->new("firstIndent"=>0,)->paragraphs(@blurb);
     $blurb = join "\n", @blurb;
 
@@ -2447,7 +2447,7 @@ If you need any further information, please visit
 If this doesn't answer your questions, contact modules\@perl.org.
 
 Thank you for your prospective contributions,
-The Pause Team
+The PAUSE Team
 };
 
       my($memo) = $req->param('pause99_add_user_memo');

--- a/lib/pause_2017/templates/email/admin/edit_ml.email.ep
+++ b/lib/pause_2017/templates/email/admin/edit_ml.email.ep
@@ -21,5 +21,5 @@ Please check if they are correct.
 
 Thanks,
 --
-The PAUSE
+The PAUSE Team
 % }

--- a/lib/pause_2017/templates/email/admin/user/welcome_user.email.ep
+++ b/lib/pause_2017/templates/email/admin/user/welcome_user.email.ep
@@ -32,4 +32,4 @@ If you need any further information, please visit
 If this doesn't answer your questions, contact modules@perl.org.
 
 Thank you for your prospective contributions,
-The Pause Team
+The PAUSE Team

--- a/lib/pause_2017/templates/email/public/mailpw.email.ep
+++ b/lib/pause_2017/templates/email/public/mailpw.email.ep
@@ -25,4 +25,4 @@ the way, your old password is still valid.
 
 Thanks,
 --
-The PAUSE
+The PAUSE Team

--- a/lib/pause_2017/templates/email/user/change_passwd.email.ep
+++ b/lib/pause_2017/templates/email/user/change_passwd.email.ep
@@ -12,4 +12,4 @@ No action is required, but it would be a good idea if somebody
 would check the correctness of the new password.
 
 Thanks,
-The Pause
+The PAUSE Team

--- a/lib/pause_2017/templates/email/user/cred/edit.email.ep
+++ b/lib/pause_2017/templates/email/user/cred/edit.email.ep
@@ -15,4 +15,4 @@ Data were entered by <%== $pause->{User}{userid} %> (<%== $pause->{User}{fullnam
 Please check if they are correct.
 
 Thanks,
-The Pause
+The PAUSE Team

--- a/lib/pause_2017/templates/email/user/delete_files.email.ep
+++ b/lib/pause_2017/templates/email/user/delete_files.email.ep
@@ -18,4 +18,4 @@ Note: to encourage deletions, all of past CPAN
 glory is collected on http://history.perl.org/backpan/
 % end
 
-The Pause
+The PAUSE Team

--- a/lib/pause_2017/templates/email/user/edit_uris.email.ep
+++ b/lib/pause_2017/templates/email/user/edit_uris.email.ep
@@ -28,7 +28,7 @@ Please check if they are correct.
 
 Thanks,
 --
-The PAUSE
+The PAUSE Team
 %   }
 % }
 

--- a/lib/pause_2017/templates/email/user/reindex.email.ep
+++ b/lib/pause_2017/templates/email/user/reindex.email.ep
@@ -11,5 +11,5 @@ Estimated time of job completion: <%== $pause->{eta} %>
 
 Thanks,
 --
-The PAUSE
+The PAUSE Team
 

--- a/lib/pause_2017/templates/email/user/reset_version.email.ep
+++ b/lib/pause_2017/templates/email/user/reset_version.email.ep
@@ -9,4 +9,4 @@ packages have their recorded version set to 'undef'.
 
 Thanks,
 --
-The PAUSE
+The PAUSE Team

--- a/lib/pause_2017/templates/email/user/uri/submission.email.ep
+++ b/lib/pause_2017/templates/email/user/uri/submission.email.ep
@@ -27,4 +27,4 @@ from the indexer a little later (usually within 1 hour).
 
 Thanks for your contribution,
 --
-The PAUSE
+The PAUSE Team


### PR DESCRIPTION
Right now, many emails are signed off as if by the software itself, calling itself "The PAUSE" or "The Pause" or "PAUSE".  I have standardized this as "The PAUSE Team", to indicate it's from humans.

Signing off as the software is fine, but I a bit confused when I saw an email signed as "The Pause", as we always use all caps.