### PR TITLE
Use sha256 instaed of sha1 or md5sums

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -52,6 +52,7 @@ WriteMakefile(
     LWP::UserAgent
     LWP::Protocol::https
     Digest::MD5
+    Digest::SHA
     Digest::SHA1
     Mail::Mailer
     Mail::Send

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -51,9 +51,7 @@ WriteMakefile(
     Log::Dispatchouli::Global
     LWP::UserAgent
     LWP::Protocol::https
-    Digest::MD5
     Digest::SHA
-    Digest::SHA1
     Mail::Mailer
     Mail::Send
     Module::Faker::Dist

--- a/bin/paused
+++ b/bin/paused
@@ -25,9 +25,7 @@ use HTTP::Status ();
 use IO::File ();
 use IPC::Run3 ();
 use LWP ();
-use Digest::MD5 ();
 use Digest::SHA ();
-use Digest::SHA1 ();
 use Mail::Send ();
 use PAUSE::MailAddress ();
 use POSIX ":sys_wait_h";
@@ -145,7 +143,6 @@ sub send {
 
 package mypause_daemon_inspector;
 
-use Fcntl qw(SEEK_SET);
 use List::Util qw(max);
 
 # package mypause_daemon_inspector
@@ -505,22 +502,14 @@ sub welcome_file {
 
   $hash->{dgot} = $self->{NOW};
   $self->logge("Info: Got $hash->{uriid} (size $size)");
-  my $md5 = Digest::MD5->new;
   my $sha = Digest::SHA->new('sha256');
-  my $sha1 = Digest::SHA1->new;
   my $handle = IO::File->new;
   unless ( $handle->open("<$PAUSE::Config->{MLROOT}$hash->{uriid}\0") ){
     die "open $PAUSE::Config->{MLROOT}$hash->{uriid}: $!";
   }
-  $md5->addfile($handle);
-  $handle->seek(SEEK_SET, 0);
   $sha->addfile($handle);
-  $handle->seek(SEEK_SET, 0);
-  $sha1->addfile($handle);
   $handle->close;
-  my $hexdigest = $md5->hexdigest;
   my $shahexdigest = $sha->hexdigest;
-  my $sha1hexdigest = $sha1->hexdigest;
   my($userid) = PAUSE::dir2user($hash->{uriid});
   my $sth2 = $self->{STH2};
   $sth2->execute($userid) or warn;
@@ -547,8 +536,6 @@ has entered CPAN as
 
   file: \$CPAN/authors/id/$hash->{uriid}
   size: $size bytes
-   md5: $hexdigest
-  sha1: $sha1hexdigest
 sha256: $shahexdigest
 };
 

--- a/bin/paused
+++ b/bin/paused
@@ -26,6 +26,7 @@ use IO::File ();
 use IPC::Run3 ();
 use LWP ();
 use Digest::MD5 ();
+use Digest::SHA ();
 use Digest::SHA1 ();
 use Mail::Send ();
 use PAUSE::MailAddress ();
@@ -505,6 +506,7 @@ sub welcome_file {
   $hash->{dgot} = $self->{NOW};
   $self->logge("Info: Got $hash->{uriid} (size $size)");
   my $md5 = Digest::MD5->new;
+  my $sha = Digest::SHA->new('sha256');
   my $sha1 = Digest::SHA1->new;
   my $handle = IO::File->new;
   unless ( $handle->open("<$PAUSE::Config->{MLROOT}$hash->{uriid}\0") ){
@@ -512,9 +514,12 @@ sub welcome_file {
   }
   $md5->addfile($handle);
   $handle->seek(SEEK_SET, 0);
+  $sha->addfile($handle);
+  $handle->seek(SEEK_SET, 0);
   $sha1->addfile($handle);
   $handle->close;
   my $hexdigest = $md5->hexdigest;
+  my $shahexdigest = $sha->hexdigest;
   my $sha1hexdigest = $sha1->hexdigest;
   my($userid) = PAUSE::dir2user($hash->{uriid});
   my $sth2 = $self->{STH2};
@@ -544,6 +549,7 @@ has entered CPAN as
   size: $size bytes
    md5: $hexdigest
   sha1: $sha1hexdigest
+sha256: $shahexdigest
 };
 
   my $di = CPAN::DistnameInfo->new($hash->{uriid});

--- a/lib/PAUSE.pm
+++ b/lib/PAUSE.pm
@@ -23,6 +23,7 @@ use File::Spec ();
 use IO::File ();
 use List::Util ();
 use Digest::MD5 ();
+use Digest::SHA ();
 use Digest::SHA1 ();
 use Mail::Send ();
 use Sys::Hostname ();
@@ -234,7 +235,7 @@ sub downtimeinfo {
 
 sub filehash {
   my($file) = @_;
-  my($ret,$authorfile,$size,$md5,$sha1,$hexdigest,$sha1hexdigest);
+  my($ret,$authorfile,$size,$md5,$sha,$sha1,$hexdigest,$shahexdigest,$sha1hexdigest);
   $ret = "";
   if (substr($file,0,length($Config->{MLROOT})) eq $Config->{MLROOT}) {
     $authorfile = "\$CPAN/authors/id/" .
@@ -244,6 +245,7 @@ sub filehash {
   }
   $size = -s $file;
   $md5 = Digest::MD5->new;
+  $sha = Digest::SHA->new('sha256');
   $sha1 = Digest::SHA1->new;
   local *HANDLE;
   unless ( open HANDLE, "< $file\0" ){
@@ -251,15 +253,19 @@ sub filehash {
   }
   $md5->addfile(*HANDLE);
   seek(HANDLE, SEEK_SET, 0);
+  $sha->addfile(*HANDLE);
+  seek(HANDLE, SEEK_SET, 0);
   $sha1->addfile(*HANDLE);
   close HANDLE;
   $hexdigest = $md5->hexdigest;
+  $shahexdigest = $sha->hexdigest;
   $sha1hexdigest = $sha1->hexdigest;
   $ret .= qq{
   file: $authorfile
   size: $size bytes
    md5: $hexdigest
   sha1: $sha1hexdigest
+sha256: $shahexdigest
 };
   return $ret;
 }

--- a/t/pause.t
+++ b/t/pause.t
@@ -25,8 +25,6 @@ subtest "PAUSE::filehash md5sum/sha1sum" => sub {
 
   file: t//data/files/somefile.txt
   size: 12 bytes
-   md5: d7e288e2c268b456c3892c3f297dad3a
-  sha1: a80338ff32a9b2d4550be8ceb93921f1ce73b343
 sha256: f4094f79a8979ace80cc375ab6c1dc640cceee36249ce03928d7e54f7ad66234
 EOF
 

--- a/t/pause.t
+++ b/t/pause.t
@@ -27,6 +27,7 @@ subtest "PAUSE::filehash md5sum/sha1sum" => sub {
   size: 12 bytes
    md5: d7e288e2c268b456c3892c3f297dad3a
   sha1: a80338ff32a9b2d4550be8ceb93921f1ce73b343
+sha256: f4094f79a8979ace80cc375ab6c1dc640cceee36249ce03928d7e54f7ad66234
 EOF
 
 };


### PR DESCRIPTION
This closes https://github.com/andk/pause/issues/352

I decided to remove the sha1sum and the md5sum from the mails; if we think md5sums and sha1sums are no longer 'safe' then we should not provide it to users; otherwise they might still be using those to compare their files! I made it separate commits so you can do otherwise as you see fit; but feel free to squash them or if you want of course I can also do that.

BTW I came here via this comment on the release of a new Perl: https://www.nntp.perl.org/group/perl.perl5.porters/2022/01/msg262480.html

I found out that the release manager pastes the shasum from the pause email; so I went looking how to provide sha256 there, and that lead to this PR. 

Thanks in advance!