### PR TITLE
Remove references to defunct PrePAN

### DIFF
--- a/htdocs/04pause.html
+++ b/htdocs/04pause.html
@@ -142,12 +142,7 @@ modules on <a href="https://metacpan.org">metacpan.org</a>.
 
 <blockquote>
 <p><strong>If you have never uploaded a module to CPAN before (and even if you have),
-you are strongly encouraged to get feedback  on
-<a href="http://prepan.org/">PrePAN</a></strong>.</p></blockquote>
-
-<p><a href="http://prepan.org/">PrePAN</a> is a site dedicated to discussing ideas for CPAN modules with other
-Perl developers and is a great resource for new (and experienced) Perl
-developers.  You can also consider discussing your ideas in other local
+you are strongly encouraged to discuss your ideas in local
 <a href="http://www.perl.org/community.html">community groups</a> or
 online community sites like <a href="http://www.perlmonks.org/">Perl Monks</a>.
 </p>

--- a/lib/pause_1999/edit.pm
+++ b/lib/pause_1999/edit.pm
@@ -2446,10 +2446,6 @@ If you need any further information, please visit
   \$CPAN/modules/04pause.html.
 If this doesn't answer your questions, contact modules\@perl.org.
 
-Before uploading your first module, we strongly encourage you to discuss
-your module idea on PrePAN at http://prepan.org/ to get feedback from
-experienced Perl developers.
-
 Thank you for your prospective contributions,
 The Pause Team
 };

--- a/lib/pause_2017/templates/email/admin/user/welcome_user.email.ep
+++ b/lib/pause_2017/templates/email/admin/user/welcome_user.email.ep
@@ -31,9 +31,5 @@ If you need any further information, please visit
   $CPAN/modules/04pause.html.
 If this doesn't answer your questions, contact modules@perl.org.
 
-Before uploading your first module, we strongly encourage you to discuss
-your module idea on PrePAN at http://prepan.org/ to get feedback from
-experienced Perl developers.
-
 Thank you for your prospective contributions,
 The Pause Team


### PR DESCRIPTION
Perl/perl5#20303 notes prepan.org is defunct; it now hosts a Japanese promotional blog