### PR TITLE
LWP::UserAgent: require TLSv12, stop trying to use SSLv3

### DIFF
--- a/bin/paused
+++ b/bin/paused
@@ -155,7 +155,9 @@ sub loop () { # we're NOT called as a method
 
   our $UA;
   unless ($UA) {
-    $UA =  LWP::UserAgent->new;
+    $UA =  LWP::UserAgent->new(
+      ssl_opts => { SSL_version => "TLSv12" },
+    );
     $UA->timeout($PAUSE::Config->{TIMEOUT}) if $PAUSE::Config->{TIMEOUT};
   }
 
@@ -677,7 +679,10 @@ sub getit {
   }
 
   our $UA;
-  my $response = $UA->request($request,$tpath);
+  my $response = $UA->request(
+    $request,
+    $tpath,
+  );
 
   if ($response->code == &HTTP::Status::RC_NOT_MODIFIED) {
     $self->logge("Alert: no mirror: RC_NOT_MODIFIED for $tpath");


### PR DESCRIPTION
I'm not sure this is right, but if you look at today's logs, you'll see that PAUSE got stuck unable to fetch an upload because PAUSE wanted to use old SSLv3.

```
2023-01-14 00:21:17 $3234 v1049: Info: Requesting a GET on uri [https://www.perturb.org/tmp/Date-Parse-Modern-0.1.tar.gz] (paused:671)
2023-01-14 00:21:18 $3234 v1049: Alert: nosuccesscount[6] error[Can't connect to www.perturb.org:443 (certificate verify failed)] (paused:701)
```

This is probably right-er, but may be too much?