### PR TITLE
use Email::Sender rather than Mail::Send

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -53,7 +53,6 @@ WriteMakefile(
     LWP::Protocol::https
     Digest::SHA
     Mail::Mailer
-    Mail::Send
     Module::Faker::Dist
     Module::Signature
     Moo

--- a/bin/paused
+++ b/bin/paused
@@ -26,7 +26,8 @@ use IO::File ();
 use IPC::Run3 ();
 use LWP ();
 use Digest::SHA ();
-use Mail::Send ();
+use Email::MIME ();
+use Email::Sender::Simple ();
 use PAUSE::MailAddress ();
 use POSIX ":sys_wait_h";
 use Path::Tiny;
@@ -124,21 +125,27 @@ our %hp_inside;
 
 sub send {
   my($self,$header,$blurb) = @_;
-  my(%tosubj);
-  for my $h (qw(To Subject)) {
-    $tosubj{$h} = delete $header->{$h};
-  }
-  my $msg = Mail::Send->new(%tosubj);
-  if (%$header) {
-    $msg->add(%$header);
-  }
-  $msg->add("From" => "PAUSE <$PAUSE::Config->{UPLOAD}>") unless exists $header->{From};
-  $msg->add("Content-Type" => "Text/Plain; Charset=UTF-8");
-  $msg->add("MIME-Version" => "1.0");
-  $msg->add("Content-Transfer-Encoding" => "8bit");
-  my $fh = $msg->open('sendmail');
-  print $fh $blurb;
-  close $fh;
+
+  my %from  = exists $header->{From}
+            ? ()
+            : (From => "PAUSE <$PAUSE::Config->{UPLOAD}>");
+
+  my $email = Email::MIME->create(
+    attributes => {
+      content_type  => 'text/plain',
+      charset       => 'utf-8',
+      encoding      => '8bit',
+    },
+    header_str => [
+      To      => delete $header->{To},
+      Subject => delete $header->{Subject},
+      %from,
+      %$header,
+    ],
+    body_str => $blurb,
+  );
+
+  Email::Sender::Simple->send($email);
 }
 
 package mypause_daemon_inspector;

--- a/cpanfile
+++ b/cpanfile
@@ -29,7 +29,6 @@ requires 'LWP';
 requires 'List::MoreUtils';
 requires 'Log::Dispatch::Config';
 requires 'Log::Dispatchouli';
-requires 'Mail::Send';
 requires 'Module::Signature';
 requires 'MojoX::Log::Dispatch::Simple';
 requires 'Mojolicious';

--- a/cron/cron-daily.pl
+++ b/cron/cron-daily.pl
@@ -6,12 +6,15 @@ use PAUSE ();
 
 use File::Basename ();
 use DBI;
-use Mail::Send     ();
+use Email::MIME;
 use File::Find     ();
 use FileHandle     ();
 use File::Copy     ();
 use HTML::Entities ();
 use IO::File       ();
+
+use Email::Sender::Simple ();
+
 use strict;
 use vars qw( $last_str $last_time $SUBJECT @listing $Dbh);
 
@@ -323,14 +326,22 @@ sub delete_scheduled_files {
 
 sub send_the_mail {
   $SUBJECT ||= "cron-daily.pl";
-  my $MSG = Mail::Send->new(
-    Subject => $SUBJECT,
-    To      => $PAUSE::Config->{ADMIN}
+
+  my $email = Email::MIME->create(
+    attributes => {
+      content_type  => 'text/plain',
+      charset       => 'utf-8',
+      encoding      => '8bit',
+    },
+    header_str => [
+      Subject => $SUBJECT,
+      To      => $PAUSE::Config->{ADMIN},
+      From    => "cron daemon cron-daily.pl <upload>",
+    ],
+    body_str => join(q{}, @blurb),
   );
-  $MSG->add("From", "cron daemon cron-daily.pl <upload>");
-  my $FH = $MSG->open('sendmail');
-  print $FH join "", @blurb;
-  $FH->close;
+
+  Email::Sender::Simple->send($email);
 }
 
 sub do_log {

--- a/lib/Bundle/Pause.pm
+++ b/lib/Bundle/Pause.pm
@@ -100,7 +100,6 @@ Mail::Field 1.02
 Mail::Header 1.01
 Mail::Internet 1.23
 Mail::Mailer 1.07
-Mail::Send 1.04
 Mail::Util 1.10
 Net::Cmd 2.00
 Net::Domain 2.00

--- a/lib/PAUSE.pm
+++ b/lib/PAUSE.pm
@@ -23,7 +23,6 @@ use File::Spec ();
 use IO::File ();
 use List::Util ();
 use Digest::SHA ();
-use Mail::Send ();
 use Sys::Hostname ();
 use Time::Piece;
 use YAML::Syck;


### PR DESCRIPTION
We already use Email::Sender in a number of places, and this converts the rest.  This is being done so that the mail transport can be configured a single way for testing, and later maybe in configuration for various Docker environments.