### PR TITLE
refactor "may file be overwritten" code (and add Markdown)

### DIFF
--- a/lib/PAUSE.pm
+++ b/lib/PAUSE.pm
@@ -553,6 +553,12 @@ sub isa_regular_perl {
   return scalar $filename =~ $ISA_REGULAR_PERL;
 }
 
+sub may_overwrite_file {
+  my ($filename) = @_;
+
+  return $filename =~ /(readme|\.html|\.txt|\.[xy]ml|\.json|\.[pr]df|\.pod)(\.gz|\.bz2)?$/i;
+}
+
 package PAUSE::DBError;
 
 sub new {

--- a/lib/PAUSE.pm
+++ b/lib/PAUSE.pm
@@ -563,6 +563,8 @@ sub may_overwrite_file {
   return 1 if $filename =~ /\.
     ( html
     | txt
+    | mkdn
+    | md
     | xml
     | yml
     | json

--- a/lib/PAUSE.pm
+++ b/lib/PAUSE.pm
@@ -556,7 +556,23 @@ sub isa_regular_perl {
 sub may_overwrite_file {
   my ($filename) = @_;
 
-  return $filename =~ /(readme|\.html|\.txt|\.[xy]ml|\.json|\.[pr]df|\.pod)(\.gz|\.bz2)?$/i;
+  my $is_archive = $filename =~ s/\.(gz|bz2)$//i;
+
+  return 1 if $filename =~ /readme$/i;
+
+  return 1 if $filename =~ /\.
+    ( html
+    | txt
+    | xml
+    | yml
+    | json
+    | pdf
+    | rdf
+    | pod
+    )
+  $/ix;
+
+  return;
 }
 
 package PAUSE::DBError;

--- a/lib/pause_2017/PAUSE/Web/Controller/User/Uri.pm
+++ b/lib/pause_2017/PAUSE/Web/Controller/User/Uri.pm
@@ -224,12 +224,7 @@ try again or report errors to <a href="mailto:}),
                 255 characters.");
       }
 
-    ALLOW_OVERWRITE: if (
-          $filename =~ /(readme|\.html|\.txt|\.[xy]ml|\.json|\.[pr]df|\.pod)(\.gz|\.bz2)?$/i
-          ||
-          $uriid =~ m!^C/CN/CNANDOR/(?:mp_(?:app|debug|doc|lib|source|tool)|VISEICat(?:\.idx)?|VISEData)!
-         ) {
-        # Overwriting allowed
+    ALLOW_OVERWRITE: if (PAUSE::may_overwrite_file($filename)) {
         $dbh->do("DELETE FROM uris WHERE uriid = ?", undef, $uriid);
       }
 

--- a/t/pause.t
+++ b/t/pause.t
@@ -30,4 +30,29 @@ EOF
 
 };
 
+subtest "PAUSE::may_overwrite_file" => sub {
+  my @may = qw(
+    readme
+    README
+    README.md
+    docs.txt
+    spec.mkdn
+    01-Super-Important.pdf
+  );
+
+  my @maynt = qw(
+    Dist-Zilla
+    Dist-Zilla.pm
+    Dist-Zilla.tar
+  );
+
+  for my $file (map {; $_, "$_.gz", "$_.bz2" } @may) {
+    ok(PAUSE::may_overwrite_file($file), "may overwrite $file");
+  }
+
+  for my $file (map {; $_, "$_.gz", "$_.bz2" } @maynt) {
+    ok(!PAUSE::may_overwrite_file($file), "may not overwrite $file");
+  }
+};
+
 done_testing;


### PR DESCRIPTION
This came up during a discussion of "what files can be overwritten?"  I looked it up, found it in a place that is harder to test, and moved it to somewhere simpler.

I also…
1. removed an ancient exception that is long-unused
2. added Markdown extensions
3. permit README.gz, mostly as an accident of refactoring