### PR TITLE
Apply some style to an error message to highlight

### DIFF
--- a/htdocs/pause/pause_2017.css
+++ b/htdocs/pause/pause_2017.css
@@ -160,3 +160,19 @@ td.checkbox { padding: 0em; text-align: center; vertical-align: middle; }
 p.notice {
   font-weight: bold;
 }
+div.info {
+  color: #004085;
+  background-color: #cce5ff;
+  border-color: #b8daff;
+}
+div.error {
+  color: #721c24;
+  background-color: #f8d7da;
+  border-color: #f5c6cb;
+}
+div.messagebox {
+  padding: 0.75rem 1.25rem;
+  margin-bottom: 1rem;
+  border: 1px solid transparent;
+  border-radius: 0.25rem;
+}

--- a/lib/pause_2017/PAUSE/Web/Controller/User/Cred.pm
+++ b/lib/pause_2017/PAUSE/Web/Controller/User/Cred.pm
@@ -29,19 +29,19 @@ sub edit {
     my $wantalias = $req->param("pause99_edit_cred_cpan_mail_alias");
     my $addr_spec = $Email::Address::addr_spec;
     if ($wantemail=~/^\s*$/ && $wantsecretemail=~/^\s*$/) {
-      $pause->{no_email} = 1;
+      $pause->{error}{no_email} = 1;
     } elsif ($wantalias eq "publ" && $wantemail=~/^\s*$/) {
-      $pause->{no_public_email} = 1;
+      $pause->{error}{no_public_email} = 1;
     } elsif ($wantalias eq "publ" && $wantemail=~/\Q$cpan_alias\E/i) {
-      $pause->{public_is_cpan_alias} = 1;
+      $pause->{error}{public_is_cpan_alias} = 1;
     } elsif ($wantalias eq "secr" && $wantsecretemail=~/^\s*$/) {
-      $pause->{no_secret_email} = 1;
+      $pause->{error}{no_secret_email} = 1;
     } elsif ($wantalias eq "secr" && $wantsecretemail=~/\Q$cpan_alias\E/i) {
-      $pause->{secret_is_cpan_alias} = 1;
+      $pause->{error}{secret_is_cpan_alias} = 1;
     } elsif (defined $wantsecretemail && $wantsecretemail!~/^\s*$/ && $wantsecretemail!~/^\s*$addr_spec\s*$/) {
-      $pause->{invalid_secret} = 1;
+      $pause->{error}{invalid_secret} = 1;
     } elsif (defined $wantemail && $wantemail!~/^\s*$/ && $wantemail!~/^\s*$addr_spec\s*$/ && $wantemail ne 'CENSORED') {
-      $pause->{invalid_public} = 1;
+      $pause->{error}{invalid_public} = 1;
     } else {
       $consistentsubmit = 1;
     }
@@ -50,7 +50,7 @@ sub edit {
       # more testing: make sure that we have in asciiname only ascii
       if (my $wantasciiname = $req->param("pause99_edit_cred_asciiname")) {
         if ($wantasciiname =~ /[^\040-\177]/) {
-          $pause->{not_ascii} = 1;
+          $pause->{error}{not_ascii} = 1;
           $consistentsubmit = 0;
         } else {
           # set asciiname to empty if it equals fullname

--- a/lib/pause_2017/templates/user/cred/edit.html.ep
+++ b/lib/pause_2017/templates/user/cred/edit.html.ep
@@ -11,37 +11,46 @@
 </h3>
 
 % if (param("pause99_edit_cred_sub")) {
-%   if ($pause->{no_email}) {
-<b>ERROR</b>: Both of your email fields are left blank, this is not the way it is intended on PAUSE, PAUSE must be able to contact you. Please fill out at least one of the two email fields.<hr>
-%   } elsif ($pause->{no_public_email}) {
-<b>ERROR</b>: You chose your email alias on CPAN to point to your public email address but your public email address is left blank. Please either pick a different choice for the alias or fill in a public email address.<hr>
-%   } elsif ($pause->{public_is_cpan_alias}) {
-<b>ERROR</b>: You chose your email alias on CPAN to point to your public email address but your public email address field contains <%= $cpan_alias %>. This looks like a circular reference. Please either pick a different choice for the alias or fill in a more reasonable public email address.<hr>
-%   } elsif ($pause->{no_secret_email}) {
-<b>ERROR</b>: You chose your email alias on CPAN to point to your secret email address but your secret email address is left blank. Please either pick a different choice for the alias or fill in a secret email address.<hr>
-%   } elsif ($pause->{secret_is_cpan_alias}) {
-<b>ERROR</b>: You chose your email alias on CPAN to point to your secret email address but your secret email address field contains <%= $cpan_alias %>. This looks like a circular reference. Please either pick a different choice for the alias or fill in a more reasonable secret email address.<hr>
-%   } elsif ($pause->{invalid_secret}) {
-<b>ERROR</b>: Your secret email address doesn't look like valid email address.<hr>
-%   } elsif ($pause->{invalid_public}) {
-<b>ERROR</b>: Your public email address doesn't look like valid email address.<hr>
-%   } else {
-
-%     if ($pause->{not_ascii}) {
-<b>ERROR</b>: Your asciiname seems to contain non-ascii characters.
+%   if (my $error = $pause->{error}) {
+<div class="messagebox error">
+<b>ERROR</b>:
+%     if ($error->{no_email}) {
+Both of your email fields are left blank, this is not the way it is intended on PAUSE, PAUSE must be able to contact you. Please fill out at least one of the two email fields.
+%     } elsif ($error->{no_public_email}) {
+You chose your email alias on CPAN to point to your public email address but your public email address is left blank. Please either pick a different choice for the alias or fill in a public email address.
+%     } elsif ($error->{public_is_cpan_alias}) {
+You chose your email alias on CPAN to point to your public email address but your public email address field contains <%= $cpan_alias %>. This looks like a circular reference. Please either pick a different choice for the alias or fill in a more reasonable public email address.
+%     } elsif ($error->{no_secret_email}) {
+You chose your email alias on CPAN to point to your secret email address but your secret email address is left blank. Please either pick a different choice for the alias or fill in a secret email address.
+%     } elsif ($error->{secret_is_cpan_alias}) {
+You chose your email alias on CPAN to point to your secret email address but your secret email address field contains <%= $cpan_alias %>. This looks like a circular reference. Please either pick a different choice for the alias or fill in a more reasonable secret email address.
+%     } elsif ($error->{invalid_secret}) {
+Your secret email address doesn't look like valid email address.
+%     } elsif ($error->{invalid_public}) {
+Your public email address doesn't look like valid email address.
+%     } elsif ($error->{not_ascii}) {
+Your asciiname seems to contain non-ascii characters.
 %     }
+</div>
+<hr>
 %   }
 % }
 
 % if ($pause->{consistentsubmit}) {
 %   for my $table ("users", $PAUSE::Config->{AUTHEN_USER_TABLE}) {
 %     if ($pause->{registered}{$table}) {
-The new data are registered in table <%= $table %>.<hr>
+<div class="messagebox info">
+The new data are registered in table <%= $table %>.
+</div>
+<hr>
 
 %     }
 %   }
 %   if (!$pause->{saw_a_change}) {
-No change seen, nothing done.<hr>
+<div class="messagebox info">
+No change seen, nothing done.
+</div>
+<hr>
 %   }
 % }
 


### PR DESCRIPTION
This PR fixes a part of https://github.com/andk/pause/issues/295  by applying some style to the error message shown in the Edit Account Info page. Highlighting the field(s) with the error is not implemented yet (maybe later).