### PR TITLE
remove an ancient hack for mod_perl 1

### DIFF
--- a/lib/PAUSE.pm
+++ b/lib/PAUSE.pm
@@ -164,10 +164,6 @@ sub basename_matches_package {
     $file =~ s|\.pm(?:\.PL)?||;
     my $ret = $package =~ m/\b\Q$file\E$/;
     $ret ||= 0;
-    unless ($ret) {
-        # Apache::mod_perl_guide stuffs it into Version.pm
-        $ret = 1 if lc $file eq 'version';
-    }
 
     $Logger->log([
       "result of basename_matches_package: %s", {


### PR DESCRIPTION
We no longer really understand it or its purpose, but mod_perl 1 is dead as a doornail.

This addresses #41.