### PR TITLE
tests: cope with default git branch being main (not master)

### DIFF
--- a/t/mldistwatch-big.t
+++ b/t/mldistwatch-big.t
@@ -67,8 +67,9 @@ subtest "first indexing" => sub {
 
   subtest "meagre git tests" => sub {
     ok(
-      -e $result->tmpdir->file('git/.git/refs/heads/master'),
-      "we now have a master commit",
+      -e $result->tmpdir->file('git/.git/refs/heads/master')
+        || -e $result->tmpdir->file('git/.git/refs/heads/main'),
+      "we now have a master or main commit",
     );
   };
 };


### PR DESCRIPTION
The tests use the tester's global git config, which is probably not a great idea.  Rather than try to fix that right now, though, this just updates the code to not complain if the user's default branch is "main", which is now a common configuration.