### PR TITLE
email testing: respect EMAIL_SENDER_TRANSPORT when testing

### DIFF
--- a/lib/PAUSE/dist.pm
+++ b/lib/PAUSE/dist.pm
@@ -547,11 +547,11 @@ sub mail_summary {
           "UNKNOWN (status=$status)";
           push @m, sprintf "Status: %s\n%s\n\n", $heading, "="x(length($heading)+8);
         }
-        my $tf13 = Text::Format->new(
-          bodyIndent => 13,
-          firstIndent => 13,
+        my $tf14 = Text::Format->new(
+          bodyIndent  => 14,
+          firstIndent => 14,
         );
-        my $verb_status = $tf13->format($inxst->{$p}{verb_status});
+        my $verb_status = $tf14->format($inxst->{$p}{verb_status});
         $verb_status =~ s/^\s+//; # otherwise this line is too long
         # magic words, see also report02() around line 573, same wording there,
         # exception prompted by JOESUF/libapreq2-2.12.tar.gz

--- a/t/lib/PAUSE/TestPAUSE.pm
+++ b/t/lib/PAUSE/TestPAUSE.pm
@@ -82,13 +82,13 @@ has tmpdir => (
 has email_sender_transport => (
   is      => 'rw',
   isa     => 'Str',
-  default => 'Test',
+  default => sub { $ENV{EMAIL_SENDER_TRANSPORT} // 'Test' },
 );
 
 has email_sender_transport_args => (
   is      => 'ro',
   isa     => 'HashRef[Str]',
-  default => sub { {} },
+  predicate => 'has_email_sender_transport_args',
 );
 
 sub deploy_schemas_at {
@@ -320,7 +320,9 @@ sub test_reindex {
     local $ENV{EMAIL_SENDER_TRANSPORT_transport_class} = $transport
       if $wrap_transport;
 
-    my %args = %{ $self->email_sender_transport_args };
+    my %args = $self->has_email_sender_transport_args
+             ? %{ $self->email_sender_transport_args }
+             : ();
 
     %args = map {;
       "EMAIL_SENDER_TRANSPORT_transport_arg_$_" => $args{$_}

--- a/t/losing-first-come.t
+++ b/t/losing-first-come.t
@@ -25,9 +25,6 @@ use 5.10.1;
 use lib 't/lib';
 use lib 't/privatelib';    # Stub PrivatePAUSE
 
-use Email::Sender::Transport::Test;
-$ENV{EMAIL_SENDER_TRANSPORT} = 'Test';
-
 use DBI;
 use File::Spec;
 use PAUSE;

--- a/t/mldistwatch-big.t
+++ b/t/mldistwatch-big.t
@@ -5,9 +5,6 @@ use 5.10.1;
 use lib 't/lib';
 use lib 't/privatelib'; # Stub PrivatePAUSE
 
-use Email::Sender::Transport::Test;
-$ENV{EMAIL_SENDER_TRANSPORT} = 'Test';
-
 use File::Spec;
 use PAUSE;
 use PAUSE::TestPAUSE;

--- a/t/mldistwatch-db.t
+++ b/t/mldistwatch-db.t
@@ -5,9 +5,6 @@ use 5.10.1;
 use lib 't/lib';
 use lib 't/privatelib'; # Stub PrivatePAUSE
 
-use Email::Sender::Transport::Test;
-$ENV{EMAIL_SENDER_TRANSPORT} = 'Test';
-
 use File::Spec;
 use PAUSE;
 use PAUSE::TestPAUSE;

--- a/t/mldistwatch-misc.t
+++ b/t/mldistwatch-misc.t
@@ -5,9 +5,6 @@ use 5.10.1;
 use lib 't/lib';
 use lib 't/privatelib'; # Stub PrivatePAUSE
 
-use Email::Sender::Transport::Test;
-$ENV{EMAIL_SENDER_TRANSPORT} = 'Test';
-
 use File::Spec;
 use PAUSE;
 use PAUSE::TestPAUSE;

--- a/t/pause.t
+++ b/t/pause.t
@@ -5,9 +5,6 @@ use 5.10.1;
 use lib 't/lib';
 use lib 't/privatelib';
 
-use Email::Sender::Transport::Test;
-$ENV{EMAIL_SENDER_TRANSPORT} = 'Test';
-
 use File::Spec;
 use PAUSE;
 

--- a/t/propagating-permissions.t
+++ b/t/propagating-permissions.t
@@ -12,9 +12,6 @@ use 5.10.1;
 use lib 't/lib';
 use lib 't/privatelib';    # Stub PrivatePAUSE
 
-use Email::Sender::Transport::Test;
-$ENV{EMAIL_SENDER_TRANSPORT} = 'Test';
-
 use DBI;
 use File::Spec;
 use PAUSE;

--- a/t/submodule-comaint.t
+++ b/t/submodule-comaint.t
@@ -6,9 +6,6 @@ use 5.10.1;
 use lib 't/lib';
 use lib 't/privatelib';    # Stub PrivatePAUSE
 
-use Email::Sender::Transport::Test;
-$ENV{EMAIL_SENDER_TRANSPORT} = 'Test';
-
 use File::Spec;
 use PAUSE;
 use PAUSE::TestPAUSE;

--- a/t/submodule-firstcome.t
+++ b/t/submodule-firstcome.t
@@ -6,9 +6,6 @@ use 5.10.1;
 use lib 't/lib';
 use lib 't/privatelib';    # Stub PrivatePAUSE
 
-use Email::Sender::Transport::Test;
-$ENV{EMAIL_SENDER_TRANSPORT} = 'Test';
-
 use File::Spec;
 use PAUSE;
 use PAUSE::TestPAUSE;


### PR DESCRIPTION
This updates how we use KeepDeliveries to get our default from the environment, so that we usually send just to Test, but can run the tests with Maildir in the env.  The tests will still pass, but we can see all the generated mail.

This also requires updating the existing tests to not redundantly set the EMAIL_SENDER_TRANSPORT env var.