### PR TITLE
DO NOT MERGE! No more deadlocks

### DIFF
--- a/doc/mod.schema.txt
+++ b/doc/mod.schema.txt
@@ -218,7 +218,7 @@ CREATE TABLE p6provides (
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE packages (
-  package varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  package varchar(128) NOT NULL DEFAULT '',
   version varchar(16) NOT NULL DEFAULT '',
   dist varchar(128) NOT NULL DEFAULT '',
   distname varchar(128) NOT NULL DEFAULT '',
@@ -240,7 +240,7 @@ CREATE TABLE packages (
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE perms (
   c int(10) unsigned NOT NULL AUTO_INCREMENT,
-  package char(245) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  package char(245) NOT NULL DEFAULT '',
   userid char(10) NOT NULL DEFAULT '',
   PRIMARY KEY (c),
   UNIQUE KEY pack_user (package,userid),
@@ -256,7 +256,7 @@ CREATE TABLE perms (
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE primeur (
-  package char(245) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  package char(245) NOT NULL DEFAULT '',
   userid char(10) NOT NULL DEFAULT '',
   PRIMARY KEY (package)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1 PACK_KEYS=1;

--- a/lib/PAUSE/mldistwatch.pm
+++ b/lib/PAUSE/mldistwatch.pm
@@ -368,14 +368,14 @@ sub _do_the_database_work {
     my $main_pkg = $dio->_package_governing_permission;
 
     if ($self->permissions->userid_has_permissions_on_package($dio->{USERID}, $main_pkg)) {
+      $dio->normalize_package_casing;
+
       $dbh->commit;
     } else {
       $dio->alert("Uploading user has no permissions on package $main_pkg");
       $dio->{NO_DISTNAME_PERMISSION} = 1;
       $dbh->rollback;
     }
-
-    $dio->normalize_package_casing;
 
     return 1;
   };

--- a/lib/PAUSE/package.pm
+++ b/lib/PAUSE/package.pm
@@ -627,7 +627,7 @@ has the same version number and the distro has a more recent modification time.}
   }
 
   if ($ok) {
-      my $query = qq{SELECT package, version, dist from  packages WHERE LOWER(package) = LOWER(?)};
+      my $query = qq{SELECT package, version, dist from  packages WHERE package = ?};
       my($pkg_recs) = $dbh->selectall_arrayref($query,{ Slice => {} },$package);
       if (@$pkg_recs > 1) {
           $Logger->log([
@@ -655,7 +655,7 @@ Please report the case to the PAUSE admins at modules\@perl.org.},
         UPDATE  packages
         SET     package = ?, version = ?, dist = ?, file = ?,
                 filemtime = ?, pause_reg = ?
-        WHERE LOWER(package) = LOWER(?)
+        WHERE package = ?
       };
 
       $Logger->log([
@@ -846,7 +846,7 @@ sub checkin {
     qq{
       SELECT package, version, dist, filemtime, file
       FROM packages
-      WHERE LOWER(package) = LOWER(?)
+      WHERE package = ?
     },
     undef,
     $package

--- a/t/lib/PAUSE/TestPAUSE/Result.pm
+++ b/t/lib/PAUSE/TestPAUSE/Result.pm
@@ -77,7 +77,7 @@ sub package_list_ok {
 
   my $p = $self->packages_data;
 
-  my @packages = sort { $a->package cmp $b->package } $p->packages;
+  my @packages = sort { lc $a->package cmp lc $b->package } $p->packages;
 
   cmp_deeply(
     \@packages,

--- a/t/mldistwatch-misc.t
+++ b/t/mldistwatch-misc.t
@@ -455,39 +455,6 @@ subtest "check perl6 distribution indexing" => sub {
   );
 };
 
-subtest "sort of case-conflicted packages is stable" => sub {
-  my $pause = PAUSE::TestPAUSE->init_new;
-
-  my $result = $pause->test_reindex;
-  my $dbh = $result->connect_mod_db;
-
-  $dbh->do("INSERT INTO packages ('package','version','dist','status','file') VALUES ('Bug::Gold','1.001','O/OP/OPRIME/Bug-Gold-1.001.tar.gz','index','notexists')");
-  $dbh->do("INSERT INTO packages ('package','version','dist','status','file') VALUES ('Bug::gold','0.001','O/OP/OPRIME/Bug-gold-0.001.tar.gz','index','notexists')");
-
-  my $now  = time - 86400;
-  my $then = time - 86400*30;
-
-  $dbh->do("INSERT INTO distmtimes ('dist','distmtime') VALUES ('O/OP/OPRIME/Bug-gold-0.001.tar.gz','$then')");
-  $dbh->do("INSERT INTO distmtimes ('dist','distmtime') VALUES ('O/OP/OPRIME/Bug-Gold-1.001.tar.gz','$now')");
-
-  for my $fn (qw(Bug-gold-0.001.tar.gz Bug-Gold-1.001.tar.gz)) {
-    my $dir = $pause->tmpdir->subdir( qw(cpan authors id O OP OPRIME) );
-    $dir->mkpath;
-
-    open my $fh, ">", $dir->file($fn) or die "Could not open: $!";
-    print $fh qq<fake tarball>;
-    close $fh or die "Could not close: $!";
-  }
-
-  $result = $pause->test_reindex;
-  $result->package_list_ok(
-    [
-      { package => 'Bug::Gold',      version => '1.001' },
-      { package => 'Bug::gold',      version => '0.001' },
-    ]
-  );
-};
-
 subtest "we should not identify version comparison as assignment" => sub {
   my $pause = PAUSE::TestPAUSE->init_new;
   $pause->upload_author_fake(PERSON => 'Version-Cmp-1.234.tar.gz', {

--- a/t/submodule-firstcome.t
+++ b/t/submodule-firstcome.t
@@ -30,10 +30,10 @@ my @existing_permissions = map {
 
 # ... and therefore, we should only index Acme::Playpen::*
 my $expected_package_list = [
-    { package => 'Acme::Playpen',            version => '0.20' },
-    { package => 'Acme::Playpen::Utilities', version => 'undef' },
-    { package => 'Acme::Playpen::_common',   version => 'undef' },
     { package => 'Acme::odometer',           version => '0.20' },
+    { package => 'Acme::Playpen',            version => '0.20' },
+    { package => 'Acme::Playpen::_common',   version => 'undef' },
+    { package => 'Acme::Playpen::Utilities', version => 'undef' },
     ### { package => 'Acme::STUDY::PERL',        version => '2.00' }, ### WRONG
 ];
 


### PR DESCRIPTION
Fixes #406 

This cannot be done until the database is cleaned up of duplicates however. (Soon, I hope!)

To use this, we'll first have to do:
```
ALTER TABLE perms MODIFY `package` char(245) NOT NULL DEFAULT '';
ALTER TABLE packages MODIFY `package` varchar(128) NOT NULL DEFAULT '';
ALTER TABLE primeur MODIFY `package` char(245) NOT NULL DEFAULT ''; 
```