### PR TITLE
Require Path::Tiny 0.070+

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -38,7 +38,7 @@ requires 'Net::SSLeay', '1.49';
 requires 'Parse::CPAN::Packages';
 requires 'Parse::CPAN::Perms';
 requires 'Path::Class';
-requires 'Path::Tiny';
+requires 'Path::Tiny', '0.070'; # for copy
 requires 'Plack::Request';
 requires 'Plack::App::Directory::Apaxy';
 requires 'Plack::Middleware::ReverseProxy';


### PR DESCRIPTION
This should fix https://github.com/andk/pause/issues/421 (after Path::Tiny on the site is also updated)