### PR TITLE
Add lc_package columns to avoid timeout/deadlock

### DIFF
--- a/doc/mod.schema.txt
+++ b/doc/mod.schema.txt
@@ -219,6 +219,7 @@ CREATE TABLE p6provides (
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE packages (
   package varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  lc_package varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   version varchar(16) NOT NULL DEFAULT '',
   dist varchar(128) NOT NULL DEFAULT '',
   distname varchar(128) NOT NULL DEFAULT '',
@@ -228,6 +229,7 @@ CREATE TABLE packages (
   `comment` varchar(255) NOT NULL DEFAULT '',
   `status` enum('index','noindex') NOT NULL DEFAULT 'index',
   PRIMARY KEY (package),
+  KEY (lc_package),
   KEY dist (dist),
   KEY distname (distname)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1 PACK_KEYS=1;
@@ -242,10 +244,12 @@ CREATE TABLE packages (
 CREATE TABLE perms (
   c int(10) unsigned NOT NULL AUTO_INCREMENT,
   package char(245) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  lc_package char(245) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   userid char(10) NOT NULL DEFAULT '',
   PRIMARY KEY (c),
   UNIQUE KEY pack_user (package,userid),
   KEY package (package),
+  KEY lc_package (lc_package),
   KEY userid (userid)
 ) ENGINE=InnoDB AUTO_INCREMENT=295236 DEFAULT CHARSET=latin1 PACK_KEYS=1;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -258,8 +262,10 @@ CREATE TABLE perms (
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE primeur (
   package char(245) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  lc_package char(245) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
   userid char(10) NOT NULL DEFAULT '',
-  PRIMARY KEY (package)
+  PRIMARY KEY (package),
+  KEY (lc_package)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1 PACK_KEYS=1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/doc/schemas/mod.schema.sqlite
+++ b/doc/schemas/mod.schema.sqlite
@@ -128,6 +128,7 @@ CREATE TABLE mods (
 --
 CREATE TABLE packages (
   package varchar(128) NOT NULL DEFAULT '',
+  lc_package varchar(128) NOT NULL DEFAULT '',
   version varchar(16) NOT NULL DEFAULT '',
   dist varchar(128) NOT NULL DEFAULT '',
   distname varchar(128) NOT NULL DEFAULT '',
@@ -140,6 +141,7 @@ CREATE TABLE packages (
 );
 
 CREATE INDEX distname ON packages (distname);
+CREATE INDEX lc_package ON packages (lc_package);
 
 --
 -- Table: perms
@@ -147,10 +149,12 @@ CREATE INDEX distname ON packages (distname);
 CREATE TABLE perms (
   c INTEGER PRIMARY KEY NOT NULL,
   package char(245) NOT NULL DEFAULT '',
+  lc_package char(245) NOT NULL DEFAULT '',
   userid char(10) NOT NULL DEFAULT ''
 );
 
 CREATE INDEX package ON perms (package);
+CREATE INDEX lc_package02 ON perms (lc_package);
 
 CREATE INDEX userid02 ON perms (userid);
 
@@ -161,9 +165,12 @@ CREATE UNIQUE INDEX pack_user ON perms (package, userid);
 --
 CREATE TABLE primeur (
   package char(245) NOT NULL DEFAULT '',
+  lc_package char(245) NOT NULL DEFAULT '',
   userid char(10) NOT NULL DEFAULT '',
   PRIMARY KEY (package)
 );
+
+CREATE INDEX lc_package03 ON primeur (lc_package);
 
 --
 -- Table: uris

--- a/lib/PAUSE.pm
+++ b/lib/PAUSE.pm
@@ -345,7 +345,7 @@ sub owner_of_module {
                    FROM mods where modid = ?},
                  primeur => qq{SELECT package,
                           userid
-                   FROM primeur where LOWER(package) = LOWER(?)},
+                   FROM primeur where lc_package = LOWER(?)},
                 );
     for my $table (qw(mods primeur)) {
         my $owner = $dbh->selectrow_arrayref($query{$table}, undef, $m);

--- a/lib/PAUSE/PermsManager.pm
+++ b/lib/PAUSE/PermsManager.pm
@@ -84,8 +84,8 @@ sub plan_package_permission_copy {
       # we disable errors so that the insert emulates an upsert
       local ( $dbh->{RaiseError} ) = 0;
       local ( $dbh->{PrintError} ) = 0;
-      my $query = "INSERT INTO perms (package, userid) VALUES (?,?)";
-      my $ret   = $dbh->do( $query, {}, $dst, $mods_userid );
+      my $query = "INSERT INTO perms (package, lc_package, userid) VALUES (?,?,?)";
+      my $ret   = $dbh->do( $query, {}, $dst, lc $dst, $mods_userid );
       my $err   = "";
       $err = $dbh->errstr unless defined $ret;
       $ret ||= "";
@@ -116,7 +116,7 @@ sub plan_set_first_come {
     # we disable errors so that the insert emulates an upsert
     local ( $dbh->{RaiseError} ) = 0;
     local ( $dbh->{PrintError} ) = 0;
-    my $ret = $dbh->do("INSERT INTO primeur (package, userid) VALUES (?,?)", undef, $package, $userid);
+    my $ret = $dbh->do("INSERT INTO primeur (package, lc_package, userid) VALUES (?,?,?)", undef, $package, lc $package, $userid);
     my $err = $@;
     $ret //= "";
 
@@ -146,7 +146,7 @@ sub plan_set_comaint {
     # we disable errors so that the insert emulates an upsert
     local ( $dbh->{RaiseError} ) = 0;
     local ( $dbh->{PrintError} ) = 0;
-    my $ret = $dbh->do("INSERT INTO perms (package, userid) VALUES (?,?)", undef, $package, $userid);
+    my $ret = $dbh->do("INSERT INTO perms (package, lc_package, userid) VALUES (?,?,?)", undef, $package, lc $package, $userid);
     my $err = $@;
     $ret //= "";
 
@@ -233,16 +233,16 @@ sub canonicalize_module_casing {
 
   for my $user (@$users) {
     $dbh->do(
-      "INSERT INTO perms (package, userid) VALUES (?, ?)",
+      "INSERT INTO perms (package, lc_package, userid) VALUES (?, ?, ?)",
       undef,
-      $package, $user->{userid},
+      $package, $lc_package, $user->{userid},
     );
 
     if ($user->{is_primary}) {
       $dbh->do(
-        "INSERT INTO primeur (package, userid) VALUES (?, ?)",
+        "INSERT INTO primeur (package, lc_package, userid) VALUES (?, ?, ?)",
         undef,
-        $package, $user->{userid},
+        $package, $lc_package, $user->{userid},
       );
     }
   }

--- a/lib/PAUSE/PermsManager.pm
+++ b/lib/PAUSE/PermsManager.pm
@@ -20,8 +20,8 @@ has dbh_callback => (
 sub get_package_first_come_any_case {
   my ($self, $pkg) = @_;
   my $dbh = $self->dbh_callback->();
-  my $query = "SELECT package, userid FROM primeur where LOWER(package) = LOWER(?)";
-  my $owner = $dbh->selectrow_arrayref($query, undef, $pkg);
+  my $query = "SELECT package, userid FROM primeur where lc_package = ?";
+  my $owner = $dbh->selectrow_arrayref($query, undef, lc $pkg);
   return $owner->[1] if $owner;
   return "";
 }
@@ -42,13 +42,13 @@ sub get_package_maintainers_list_any_case {
   my $sql = qq{
     SELECT package, userid
       FROM   primeur
-      WHERE  LOWER(package) = LOWER(?)
+      WHERE  lc_package = ?
       UNION
     SELECT package, userid
       FROM   perms
-      WHERE  LOWER(package) = LOWER(?)
+      WHERE  lc_package = ?
   };
-  my @args = ($package) x 2;
+  my @args = (lc $package) x 2;
   return $dbh->selectall_arrayref($sql, undef, @args);
 }
 
@@ -66,10 +66,10 @@ sub plan_package_permission_copy {
         q{
         SELECT userid
         FROM   perms
-        WHERE  LOWER(package) = LOWER(?)
+        WHERE  lc_package = ?
         },
         { Slice => {} },
-        $src,
+        lc $src,
         );
 
     # TODO: correctly set first-come as well
@@ -176,19 +176,19 @@ sub userid_has_permissions_on_package {
   my ($has_perms) = $dbh->selectrow_array(
     qq{
       SELECT COUNT(*) FROM perms
-      WHERE userid = ? AND LOWER(package) = LOWER(?)
+      WHERE userid = ? AND lc_package = ?
     },
     undef,
-    $userid, $package,
+    $userid, lc $package,
   );
 
   my ($has_primary) = $dbh->selectrow_array(
     qq{
       SELECT COUNT(*) FROM primeur
-      WHERE userid = ? AND LOWER(package) = LOWER(?)
+      WHERE userid = ? AND lc_package = ?
     },
     undef,
-    $userid, $package,
+    $userid, lc $package,
   );
 
   return($has_perms || $has_primary);
@@ -197,6 +197,7 @@ sub userid_has_permissions_on_package {
 sub canonicalize_module_casing {
   my ($self, $package) = @_;
 
+  my $lc_package = lc($package // '');
   my $dbh = $self->dbh_callback->();
   my $users = $dbh->selectall_arrayref(
     qq{
@@ -204,30 +205,30 @@ sub canonicalize_module_casing {
             primeur.userid,
             1 AS is_primary
             FROM primeur
-            WHERE LOWER(primeur.package) = LOWER(?)
+            WHERE primeur.lc_package = ?
         UNION
         SELECT
             perms.userid,
             0 AS is_primary
             FROM perms
-            WHERE lower(perms.package) = LOWER(?)
-                AND perms.userid NOT IN (SELECT userid FROM primeur WHERE lower(package) = LOWER(?))
+            WHERE perms.lc_package = ?
+                AND perms.userid NOT IN (SELECT userid FROM primeur WHERE lc_package = ?)
         ;
     },
     { Slice => {} },
-    ($package) x 3
+    ($lc_package) x 3
   );
 
   $dbh->do(
-    qq{DELETE FROM perms   WHERE LOWER(package) = LOWER(?)},
+    qq{DELETE FROM perms   WHERE lc_package = ?},
     undef,
-    $package,
+    $lc_package,
   );
 
   $dbh->do(
-    qq{DELETE FROM primeur WHERE LOWER(package) = LOWER(?)},
+    qq{DELETE FROM primeur WHERE lc_package = ?},
     undef,
-    $package,
+    $lc_package,
   );
 
   for my $user (@$users) {
@@ -248,10 +249,10 @@ sub canonicalize_module_casing {
 
   $dbh->do(
     qq{
-      UPDATE packages SET package = ? WHERE LOWER(package) = LOWER(?);
+      UPDATE packages SET package = ?, lc_package = ? WHERE lc_package = ?;
     },
     undef,
-    ($package) x 2,
+    $package, ($lc_package) x 2,
   );
 
   return;

--- a/lib/PAUSE/package.pm
+++ b/lib/PAUSE/package.pm
@@ -627,8 +627,8 @@ has the same version number and the distro has a more recent modification time.}
   }
 
   if ($ok) {
-      my $query = qq{SELECT package, version, dist from  packages WHERE LOWER(package) = LOWER(?)};
-      my($pkg_recs) = $dbh->selectall_arrayref($query,{ Slice => {} },$package);
+      my $query = qq{SELECT package, version, dist from  packages WHERE lc_package = ?};
+      my($pkg_recs) = $dbh->selectall_arrayref($query,{ Slice => {} }, lc $package);
       if (@$pkg_recs > 1) {
           $Logger->log([
               "conflicting records exist in packages table, won't index: %s",
@@ -653,9 +653,9 @@ Please report the case to the PAUSE admins at modules\@perl.org.},
   if ($ok) {
       my $query = qq{
         UPDATE  packages
-        SET     package = ?, version = ?, dist = ?, file = ?,
+        SET     package = ?, lc_package = ?, version = ?, dist = ?, file = ?,
                 filemtime = ?, pause_reg = ?
-        WHERE LOWER(package) = LOWER(?)
+        WHERE lc_package = ?
       };
 
       $Logger->log([
@@ -673,12 +673,13 @@ Please report the case to the PAUSE admins at modules\@perl.org.},
                                      ($query,
                                       undef,
                                       $package,
+                                      lc $package,
                                       $pp->{version},
                                       $dist,
                                       $pp->{infile},
                                       $pp->{filemtime},
                                       $self->dist->{TIME},
-                                      $package,
+                                      lc $package,
                                      );
                              };
 
@@ -846,10 +847,10 @@ sub checkin {
     qq{
       SELECT package, version, dist, filemtime, file
       FROM packages
-      WHERE LOWER(package) = LOWER(?)
+      WHERE lc_package = ?
     },
     undef,
-    $package
+    lc $package
   );
 
   if ($row) {

--- a/lib/PAUSE/package.pm
+++ b/lib/PAUSE/package.pm
@@ -748,8 +748,8 @@ sub insert_into_package {
   my $distname = CPAN::DistnameInfo->new($dist)->dist;
   my $query = qq{
     INSERT INTO packages
-      (package, version, dist, file, filemtime, pause_reg, distname)
-    VALUES (?,?,?,?,?,?,?)
+      (package, lc_package, version, dist, file, filemtime, pause_reg, distname)
+    VALUES (?,?,?,?,?,?,?,?)
   };
 
   $Logger->log([
@@ -767,6 +767,7 @@ sub insert_into_package {
   $dbh->do($query,
             undef,
             $package,
+            lc $package,
             $pp->{version},
             $dist,
             $pp->{infile},

--- a/lib/pause_1999/edit.pm
+++ b/lib/pause_1999/edit.pm
@@ -6604,13 +6604,13 @@ sub share_perms_makeco {
                  )
                 unless $sth1->rows;
         local($db->{RaiseError}) = 0;
-        my $sth = $db->prepare("INSERT INTO perms (package,userid)
-                            VALUES (?,?)");
+        my $sth = $db->prepare("INSERT INTO perms (package,lc_package,userid)
+                            VALUES (?,?,?)");
         for my $selmod (@selmods) {
           die PAUSE::HeavyCGI::Exception
               ->new(ERROR => "You do not seem to be maintainer of $selmod")
                   unless exists $all_mods->{$selmod};
-          my $ret = $sth->execute($selmod,$other_user);
+          my $ret = $sth->execute($selmod,lc $selmod,$other_user);
           my $err = "";
           $err = $db->errstr unless defined $ret;
           $ret ||= "";

--- a/lib/pause_2017/PAUSE/Web/Controller/User/Distperms.pm
+++ b/lib/pause_2017/PAUSE/Web/Controller/User/Distperms.pm
@@ -277,8 +277,8 @@ sub make_dist_comaint {
                  )
                 unless $sth1->rows;
         local($db->{RaiseError}) = 0;
-        my $sth = $db->prepare("INSERT INTO perms (package,userid)
-                            VALUES (?,?)");
+        my $sth = $db->prepare("INSERT INTO perms (package,lc_package,userid)
+                            VALUES (?,?,?)");
         my @results;
         for my $seldist (@seldists) {
           die PAUSE::Web::Exception
@@ -290,7 +290,7 @@ sub make_dist_comaint {
               WHERE packages.distname=? AND primeur.userid=?},
             undef, $seldist, $u->{userid});
           for my $selmod (@$mods) {
-            my $ret = $sth->execute($selmod,$other_user);
+            my $ret = $sth->execute($selmod,lc $selmod,$other_user);
             my $err = "";
             $err = $db->errstr unless defined $ret;
             $ret ||= "";

--- a/lib/pause_2017/PAUSE/Web/Controller/User/Perms.pm
+++ b/lib/pause_2017/PAUSE/Web/Controller/User/Perms.pm
@@ -375,15 +375,15 @@ sub _share_makeco {
                  )
                 unless $sth1->rows;
         local($db->{RaiseError}) = 0;
-        my $sth = $db->prepare("INSERT INTO perms (package,userid)
-                            VALUES (?,?)");
+        my $sth = $db->prepare("INSERT INTO perms (package,lc_package,userid)
+                            VALUES (?,?,?)");
 
         my @results;
         for my $selmod (@selmods) {
           die PAUSE::Web::Exception
               ->new(ERROR => "You do not seem to be maintainer of $selmod")
                   unless exists $all_mods->{$selmod};
-          my $ret = $sth->execute($selmod,$other_user);
+          my $ret = $sth->execute($selmod,lc $selmod,$other_user);
           my $err = "";
           $err = $db->errstr unless defined $ret;
           $ret ||= "";

--- a/one-off-utils/schemachange-2024-04.sql
+++ b/one-off-utils/schemachange-2024-04.sql
@@ -1,0 +1,9 @@
+ALTER TABLE packages ADD COLUMN lc_package varchar(128) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '';
+ALTER TABLE primeur ADD COLUMN lc_package varchar(245) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '';
+ALTER TABLE perms ADD COLUMN lc_package varchar(245) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '';
+UPDATE packages SET lc_package = LOWER(package);
+UPDATE primeur SET lc_package = LOWER(package);
+UPDATE perms SET lc_package = LOWER(package);
+ALTER TABLE packages ADD INDEX lc_package (lc_package);
+ALTER TABLE primeur ADD INDEX lc_package (lc_package);
+ALTER TABLE perms ADD INDEX lc_package (lc_package);

--- a/t/lib/PAUSE/TestPAUSE.pm
+++ b/t/lib/PAUSE/TestPAUSE.pm
@@ -139,11 +139,11 @@ sub add_first_come {
 
   $dbh->do(
     q{
-      INSERT INTO primeur (userid, package) VALUES (?, ?);
-      INSERT INTO perms   (userid, package) VALUES (?, ?);
+      INSERT INTO primeur (userid, package, lc_package) VALUES (?, ?, ?);
+      INSERT INTO perms   (userid, package, lc_package) VALUES (?, ?, ?);
     },
     undef,
-    (uc $userid, $package) x 2,
+    (uc $userid, $package, lc $package) x 2,
   );
 }
 
@@ -160,11 +160,12 @@ sub add_comaint {
 
   $dbh->do(
     q{
-      INSERT INTO perms (userid, package) VALUES (?, ?);
+      INSERT INTO perms (userid, package, lc_package) VALUES (?, ?, ?);
     },
     undef,
     uc $userid,
     $package,
+    lc $package,
   );
 }
 

--- a/t/losing-first-come.t
+++ b/t/losing-first-come.t
@@ -131,8 +131,8 @@ sub add_to_primeur
     my $db      = DBI->connect( "dbi:SQLite:dbname=$db_file", undef, undef)
                   or die "can't connect to db at $db_file: $DBI::errstr";
 
-    $db->do("INSERT INTO primeur (userid, package) VALUES (?, ?);",
-            undef, $author, $package)
+    $db->do("INSERT INTO primeur (userid, package, lc_package) VALUES (?, ?, ?);",
+            undef, $author, $package, lc $package)
         or die "couldn't add to primeur for $author/$package: $DBI::errstr\n";
 
 }

--- a/t/mldistwatch-misc.t
+++ b/t/mldistwatch-misc.t
@@ -120,13 +120,13 @@ subtest "cannot steal a library when primeur+perms exist" => refused_index_test(
 
 subtest "cannot steal a library when only primeur exists" => refused_index_test(sub {
   my ($pause, $dbh) = @_;
-  $dbh->do("INSERT INTO primeur (package, userid) VALUES ('Bug::Gold','ATRION')")
+  $dbh->do("INSERT INTO primeur (package, lc_package, userid) VALUES ('Bug::Gold','bug::gold','ATRION')")
     or die "couldn't insert!";
 });
 
 subtest "cannot steal a library when only perms exist" => refused_index_test(sub {
   my ($pause, $dbh) = @_;
-  $dbh->do("INSERT INTO perms (package, userid) VALUES ('Bug::Gold','ATRION')")
+  $dbh->do("INSERT INTO perms (package, lc_package, userid) VALUES ('Bug::Gold','bug::gold','ATRION')")
     or die "couldn't insert!";
 });
 
@@ -144,7 +144,7 @@ subtest "cannot steal a library via copy-main-perms mechanism" => refused_index_
   ],
   before      => sub {
     my ($pause, $dbh) = @_;
-    $dbh->do("INSERT INTO perms (package, userid) VALUES ('Jenkins::Hack2','ATRION')")
+    $dbh->do("INSERT INTO perms (package, lc_package, userid) VALUES ('Jenkins::Hack2','jenkins::hack2','ATRION')")
       or die "couldn't insert!";
   },
 });
@@ -458,8 +458,8 @@ subtest "sort of case-conflicted packages is stable" => sub {
   my $result = $pause->test_reindex;
   my $dbh = $result->connect_mod_db;
 
-  $dbh->do("INSERT INTO packages ('package','version','dist','status','file') VALUES ('Bug::Gold','1.001','O/OP/OPRIME/Bug-Gold-1.001.tar.gz','index','notexists')");
-  $dbh->do("INSERT INTO packages ('package','version','dist','status','file') VALUES ('Bug::gold','0.001','O/OP/OPRIME/Bug-gold-0.001.tar.gz','index','notexists')");
+  $dbh->do("INSERT INTO packages ('package','lc_package','version','dist','status','file') VALUES ('Bug::Gold','bug::gold','1.001','O/OP/OPRIME/Bug-Gold-1.001.tar.gz','index','notexists')");
+  $dbh->do("INSERT INTO packages ('package','lc_package','version','dist','status','file') VALUES ('Bug::gold','bug::gold','0.001','O/OP/OPRIME/Bug-gold-0.001.tar.gz','index','notexists')");
 
   my $now  = time - 86400;
   my $then = time - 86400*30;

--- a/t/submodule-comaint.t
+++ b/t/submodule-comaint.t
@@ -22,7 +22,7 @@ my $corpus = 'corpus/mld/submodule-comaint/authors';
 
 # However, Jenkins::Hack2 belongs to ATRION...
 my @existing_permissions = map {
-    "INSERT INTO $_ (package, userid) VALUES ('Jenkins::Hack2','ATRION')"
+    "INSERT INTO $_ (package, lc_package, userid) VALUES ('Jenkins::Hack2','jenkins::hack2','ATRION')"
 } qw/primeur perms/;
 
 # ... and therefore, we should only index Jenkins::Hack and
@@ -67,8 +67,8 @@ $result->email_ok(
 );
 
 # now lets add OOP as comaint on that and check we can upload it okay.
-$dbh->do("INSERT INTO perms (package, userid) VALUES (?,?)", {},
-        'Jenkins::Hack2','OOOPPP')
+$dbh->do("INSERT INTO perms (package, lc_package, userid) VALUES (?,?,?)", {},
+        'Jenkins::Hack2','jenkins::hack2','OOOPPP')
     or die "couldn't insert!";
 $corpus = 'corpus/mld/submodule-comaint2/authors';
 note("Indexing the corpus at [$corpus] now OOOPPP has comaint");

--- a/t/submodule-firstcome.t
+++ b/t/submodule-firstcome.t
@@ -22,7 +22,7 @@ my $corpus = 'corpus/mld/submodule-firstcome/authors';
 
 # However, Acme::Study::Perl belongs to ANDK.
 my @existing_permissions = map {
-    "INSERT INTO $_ (package, userid) VALUES ('Acme::Study::Perl','ANDK')"
+    "INSERT INTO $_ (package, lc_package, userid) VALUES ('Acme::Study::Perl','acme::study::perl','ANDK')"
 } qw/primeur perms/;
 
 # ... and therefore, we should only index Acme::Playpen::*


### PR DESCRIPTION
This PR is another fix for #406. Contrary to #424, which removes `LOWER()` so that PAUSE can use indices (but lose case-insensitivity), this PR adds indexed lc_package columns to keep the current case-insensitive search and let PAUSE use indices at the cost of some extra space.

We may need to replace some more for the web app, but I haven't thoroughly checked yet. Also, we may need to add a unique lc_pack_user index (or replace pack_user with lc_pack_user), but I'm still wondering which is better.

If you try this PR before merging, apply one-off-utils/schemachange-2024-04.sql.
