### PR TITLE
Use Parallel::Runner to limit the number of mldistwatch processes

### DIFF
--- a/bin/paused
+++ b/bin/paused
@@ -209,6 +209,11 @@ sub loop () { # we're NOT called as a method
 
   # we have a continue block, so be careful with the scope
   my($hash, $hash_orig);
+  require Parallel::Runner;
+  my $runner = Parallel::Runner->new($PAUSE::Config->{MAX_MLDISTWATCH_PROCESSES} || 4);
+  $runner->exit_callback(sub {
+    mypause_daemon_inspector->logge("Debug: Reaped child[$$]");
+  });
  URIRECORD: while ( $hash  = $sth->fetchrow_hashref ) {
     $self->{URIRECORD} = $hash;
     if ($] > 5.007) {
@@ -322,23 +327,15 @@ skip        =not yet verified
 	$self->logge("Info: Verified $hash->{uriid}");
         my $run_mldistwatch_from_paused = 1; # since Checksums 0.050 atomicity good enough?
         if ($run_mldistwatch_from_paused) {
-          $SIG{CHLD} = \&main::reaper;
-          my $pid = fork;
-          if (defined $pid) {
-            if ($pid) {
-              $self->logge("Info: Started mldistwatch for lpath[$lpath] with pid[$pid]");
-            } else {
-              # child
-              exec $^X,
-                  "$PAUSE::Config->{CRONPATH}/mldistwatch",
-                      '--pick',
-                          $lpath,
-                              '--logfile',
-                                  '/var/log/mldistwatch.log';
-            }
-          } else {
-            $self->logge("Alert: could not fork for mldistwatch: $!");
-          }
+            $runner->run(sub {
+                mypause_daemon_inspector->logge("Info: Started mldistwatch for lpath[$lpath] with pid[$$]");
+                system $^X,
+                    "$PAUSE::Config->{CRONPATH}/mldistwatch",
+                        '--pick',
+                            $lpath,
+                                '--logfile',
+                                    '/var/log/mldistwatch.log';
+            });
         }
 	next URIRECORD;
       } else {
@@ -363,6 +360,7 @@ skip        =not yet verified
     main::restart() if $mypause_daemon_inspector::Signal;
   }
 
+  $runner->finish;
   # disconnect, we want to sleep
   $sth->finish;
   $sth2->finish;

--- a/cpanfile
+++ b/cpanfile
@@ -35,6 +35,7 @@ requires 'MojoX::Log::Dispatch::Simple';
 requires 'Mojolicious';
 requires 'Mojolicious::Plugin::WithCSRFProtection';
 requires 'Net::SSLeay', '1.49';
+requires 'Parallel::Runner';
 requires 'Parse::CPAN::Packages';
 requires 'Parse::CPAN::Perms';
 requires 'Path::Class';


### PR DESCRIPTION
When you regenerate package-related tables from the existing CPAN directory to see how a patch for the indexer works, paused may spawn too many mldistwatch processes, which would cause various problems such as out-of-memory. This PR uses Parallel::Runner (by Exodist) to limit the maximum number of mldistwatch processes.