### PR TITLE
Strip BOM before parsing package version

### DIFF
--- a/lib/PAUSE/pmfile.pm
+++ b/lib/PAUSE/pmfile.pm
@@ -204,9 +204,14 @@ sub packages_per_pmfile {
     local $/ = "\n";
     my $inpod = 0;
 
+    my $checked_bom;
   PLINE: while (<$fh>) {
         chomp;
         my($pline) = $_;
+        unless ($checked_bom) {
+            $pline =~ s/\A(?:\x00\x00\xfe\xff|\xff\xfe\x00\x00|\xfe\xff|\xff\xfe|\xef\xbb\xbf)//;
+            $checked_bom = 1;
+        }
         $inpod = $pline =~ /^=(?!cut)/ ? 1 :
             $pline =~ /^=cut/ ? 0 : $inpod;
         next if $inpod;


### PR DESCRIPTION
The following-up of #173 
 
cf. https://github.com/charsbar/Parse-PMFile/commit/53729d72eae3015298a858d46afda3529d40881c