### PR TITLE
cron/cron-daily.pl: if there is no 08pumpkings, do not fail

### DIFF
--- a/cron/cron-daily.pl
+++ b/cron/cron-daily.pl
@@ -755,13 +755,16 @@ sub pumpkings {
   my $repfile = "$PAUSE::Config->{MLROOT}/../08pumpkings.txt.gz";
   my $list    = "";
   my $olist   = "";
-  local ($/) = undef;
-  if (open F, "$zcat $repfile|") {
-    if ($] > 5.007) {
-      binmode F, ":utf8";
+
+  if (-e $repfile) {
+    local ($/) = undef;
+    if (open F, "$zcat $repfile|") {
+      if ($] > 5.007) {
+        binmode F, ":utf8";
+      }
+      $olist = <F>;
+      close F;
     }
-    $olist = <F>;
-    close F;
   }
 
   my @pumpkings;


### PR DESCRIPTION
08pumpkins will not exist on the first run of the daily cron job.

That is okay!  Just treat it as if the file had been empty.