### PR TITLE
Check related checkboxes

### DIFF
--- a/lib/pause_2017/PAUSE/Web/Controller/User/Files.pm
+++ b/lib/pause_2017/PAUSE/Web/Controller/User/Files.pm
@@ -4,6 +4,7 @@ use Mojo::Base "Mojolicious::Controller";
 use HTTP::Date ();
 use File::pushd;
 use PAUSE ();
+use CPAN::DistnameInfo;
 
 sub show {
   my $c = shift;
@@ -172,10 +173,14 @@ sub delete {
       warn "ALERT: Could not stat f[$f]: $!";
       next;
     }
+    my $tmpf = $f;
+    $tmpf =~ s/\.(?:readme|meta)$/.tar.gz/;
+    my $info = CPAN::DistnameInfo->new($tmpf);
+    my $dist = $info->dist;
     my $blurb = $deletes{$f} ?
         $c->scheduled($whendele{$f}) :
             HTTP::Date::time2str((stat _)[9]);
-    $files{$f} = {stat => -s _, blurb => $blurb, indexed => $indexed->{$f} };
+    $files{$f} = {stat => -s _, blurb => $blurb, indexed => $indexed->{$f}, dist => $dist };
     $pause->{deleting_indexed_files} = 1 if $deletes{$f} && $indexed->{$f};
   }
   $pause->{files} = \%files;

--- a/lib/pause_2017/templates/user/files/delete.html.ep
+++ b/lib/pause_2017/templates/user/files/delete.html.ep
@@ -29,7 +29,7 @@
   <tbody class="list">
 % for my $file (sort keys %$files) {
     <tr>
-      <td class="checkbox"><%= check_box "pause99_delete_files_FILE" => $file %></td>
+      <td class="checkbox"><%= check_box "pause99_delete_files_FILE" => $file, 'data-dist' => $files->{$file}{dist} %></td>
 %   if ($files->{$file}{indexed}) {
       <td class="file indexed"><%= $file %> [indexed]</td>
 %   } else {

--- a/lib/pause_2017/templates/user/files/delete.html.ep
+++ b/lib/pause_2017/templates/user/files/delete.html.ep
@@ -50,6 +50,17 @@
 var List = new List('files', {
   valueNames: ['file', 'size', 'modified']
 });
+
+document.querySelectorAll('input[type=checkbox]').forEach(function(e) {
+  e.addEventListener('change', function(ev) {
+    var checked = ev.currentTarget.checked;
+    var dist = ev.currentTarget.getAttribute('data-dist');
+    document.querySelectorAll('input[data-dist='+dist+']').forEach(function(e) {
+      e.checked = checked;
+    });
+  })
+});
+
 % end
 % end
 


### PR DESCRIPTION
Should fix part of #363. This PR should allow people to check (at most) three related checkboxes with one check. Maybe we can go further if the issue noted in #427 is fixed.