### PR TITLE
selfconfig: split rsyncd.conf back into etc

### DIFF
--- a/bootstrap/selfconfig-root
+++ b/bootstrap/selfconfig-root
@@ -304,36 +304,7 @@ run_cmd(
     : ()),
 );
 
-Path::Tiny::path("/etc/rsyncd.conf")->spew(<<~'END');
-  # cat rsyncd.conf
-  max connections = 12
-  log file = /var/log/rsyncd
-  pid file = /var/run/PAUSE-rsyncd.pid
-  transfer logging = true
-  use chroot = true
-  timeout = 600
-
-  [PAUSE]
-  path = /data/pause/pub/PAUSE
-
-  [authors]
-  path = /data/pause/pub/PAUSE/authors
-
-  [modules]
-  path = /data/pause/pub/PAUSE/modules
-
-  [scripts]
-  path = /data/pause/pub/PAUSE/scripts/new
-
-  [pausedata]
-  path = /data/pause/pub/PAUSE/PAUSE-data
-
-  [pausecode]
-  path = /data/pause/pub/PAUSE/PAUSE-code
-
-  [pausegit]
-  path = /data/pause/pub/PAUSE/PAUSE-git
-  END
+Path::Tiny::path("/home/pause/pause/etc/rsyncd.conf")->copy("/etc/rsyncd.conf");
 
 run_cmd(
   qw( sudo -u pause ),

--- a/etc/rsyncd.conf
+++ b/etc/rsyncd.conf
@@ -1,27 +1,28 @@
-max connections = 4
+max connections = 12
 log file = /var/log/rsyncd
+pid file = /var/run/PAUSE-rsyncd.pid
 transfer logging = true
 use chroot = true
+timeout = 600
 
 [PAUSE]
-               path = /home/ftp/pub/PAUSE
-
-# 2005-09-03: PAUSE cannot support backpan anymore because of disk shortage.
-#[backpan]
-#               path = /home/ftp/pub/backpan
-
-# the rest of the gang is a bit silly, because the physical path is
-# tweaked. In one word: legacy
+path = /data/pause/pub/PAUSE
 
 [authors]
-               path = /home/ftp/pub/PAUSE/authors
+path = /data/pause/pub/PAUSE/authors
+
 [modules]
-               path = /home/ftp/pub/PAUSE/modules
+path = /data/pause/pub/PAUSE/modules
+
 [scripts]
-               path = /home/ftp/pub/PAUSE/scripts/new
+path = /data/pause/pub/PAUSE/scripts/new
+
 [pausedata]
-               path = /home/ftp/pub/PAUSE/PAUSE-data
+path = /data/pause/pub/PAUSE/PAUSE-data
+
 [pausecode]
-               path = /home/ftp/pub/PAUSE/PAUSE-code
+path = /data/pause/pub/PAUSE/PAUSE-code
+
 [pausegit]
-               path = /home/ftp/pub/PAUSE/PAUSE-git
+path = /data/pause/pub/PAUSE/PAUSE-git
+END


### PR DESCRIPTION
This keeps distinct files more clearly under source control.