### PR TITLE
raise max upload size

### DIFF
--- a/bootstrap/selfconfig-root
+++ b/bootstrap/selfconfig-root
@@ -263,6 +263,8 @@ upstream pause {
 server {
   listen 80 default_server;
 
+  client_max_body_size 250m;
+
   location / {
      proxy_pass http://pause;
      proxy_set_header X-Forwarded-Host \$host;


### PR DESCRIPTION
nginx defaults to 1mb client_max_body_size which is very limiting for the large POSTs that PAUSE requires.

Raise to 250mb, which is a little larger than the largest files.

Note: an upload of a 200mb file failed, but in Plack/mojo, not nginx as before. An upload of 25mb (bigger than the average perl5 release) was fine.