### PR TITLE
bootstrap: use v5.36.3, not v5.36.0

### DIFF
--- a/bootstrap/selfconfig-pause
+++ b/bootstrap/selfconfig-pause
@@ -53,8 +53,8 @@ if (-e '/tmp/plenv-tarball.tar.bz2') {
       /home/pause/.plenv/plugins/perl-build/
   ));
 
-  run_cmd(qw( /home/pause/.plenv/bin/plenv install 5.36.0 -j 16 --noman ));
-  run_cmd(qw( /home/pause/.plenv/bin/plenv global  5.36.0 ));
+  run_cmd(qw( /home/pause/.plenv/bin/plenv install 5.36.3 -j 16 --noman ));
+  run_cmd(qw( /home/pause/.plenv/bin/plenv global  5.36.3 ));
 
   # install cpanm for perl dep management
   run_cmd(qw( /home/pause/.plenv/bin/plenv install-cpanm ));


### PR DESCRIPTION
It would be nice to use v5.36.latest, but plenv does not have a trivial option for it.