### PR TITLE
etc/rsyncd.conf: log to syslog (journald), not a file

### DIFF
--- a/etc/rsyncd.conf
+++ b/etc/rsyncd.conf
@@ -1,5 +1,4 @@
 max connections = 12
-log file = /var/log/rsyncd
 pid file = /var/run/PAUSE-rsyncd.pid
 transfer logging = true
 use chroot = true


### PR DESCRIPTION
This means we get the space management from the journal.