### PR TITLE
crontab: quiet git commands

### DIFF
--- a/cron/CRONTAB.ROOT
+++ b/cron/CRONTAB.ROOT
@@ -22,7 +22,7 @@ PAUSE_ROOT=/data/pause/pub/PAUSE
 47 07,13,19,01 * * *  pause  $PAUSE_REPO/cron/mysql-dump.pl
 21 */6 * * *          pause  $PAUSE_REPO/cron/rm_stale_links
 22 * * * *            pause  $PAUSE_REPO/cron/sync-04pause.pl
-10 09,15,21,03 * * *  pause  cd $PAUSE_ROOT/PAUSE-git && (git gc && git push -u origin master) >> /home/pause/log/git-gc-push.out
+10 09,15,21,03 * * *  pause  cd $PAUSE_ROOT/PAUSE-git && (git gc -q && git push -q -u origin master)
 18 * * * *            pause  $PAUSE_REPO/cron/cron-p6daily.pl
 46 0,6,12,18 * * *    pause  perl -I $PAUSE_REPO/lib $PAUSE_REPO/bin/indexscripts.pl > $PAUSE_REPO/bin/indexscripts.pl.out 2>&1
 7 2   * * 0           pause  perl -I $PAUSE_REPO/lib $PAUSE_REPO/bin/indexscripts.pl -f


### PR DESCRIPTION
Add the -q flag to the git commands so they only output if there's an error.

This will make the cron emails less frequent and hopefully more actionable.