### PR TITLE
fix Use of uninitialized value warnings.

### DIFF
--- a/cron/cron-daily.pl
+++ b/cron/cron-daily.pl
@@ -715,6 +715,7 @@ sub authors {
       require Encode;
       for (@$author) {
         defined && /\P{ASCII}/ && Encode::_utf8_on($_);
+        $_ //= ""; # some fields are undef, make them empty instead.
       }
 
       # Surely no one has tabs in his or her email or full name, but let's


### PR DESCRIPTION
Some fields in @$author end up being undefined.  Replace them with an empty string instead.