### PR TITLE
use $Logger in cronjobs

### DIFF
--- a/cron/cleanup-incoming.pl
+++ b/cron/cleanup-incoming.pl
@@ -36,14 +36,7 @@ for my $dirent (readdir DIR) {
       next if $sth->rows > 0;
   }
   my $size = -s $absdirent;
-  if (0 && $dirent =~ /^(\d+)\.(\d+)$/) { # these come often, but I could not decipher
-    open my $fh, $absdirent or die "Could not open $absdirent: $!";
-    local $/;
-    my $str = <$fh>;
-    substr($str,100*1024) = "" if length($str)> 100*1024;
-    require Data::Dumper;
-    warn sprintf "content[%s]\n", Data::Dumper::Dumper($str);
-  }
+
   unlink $absdirent or die "Could not unlink $absdirent: $!";
   warn "unlinked $absdirent ($size)\n";
 }

--- a/cron/cleanup-incoming.pl
+++ b/cron/cleanup-incoming.pl
@@ -38,6 +38,6 @@ for my $dirent (readdir DIR) {
   my $size = -s $absdirent;
 
   unlink $absdirent or die "Could not unlink $absdirent: $!";
-  warn "unlinked $absdirent ($size)\n";
+  $Logger->log("unlinked $absdirent ($size)");
 }
 closedir DIR;

--- a/cron/cron-daily.pl
+++ b/cron/cron-daily.pl
@@ -80,7 +80,7 @@ sub read_errorlog {
     close LOG;
     report "\nErrorlog contains $errorlines lines today\n";
   } else {
-    warn "error opening $PAUSE::Config->{HTTP_ERRORLOG}: $!";
+    $Logger->log("error opening $PAUSE::Config->{HTTP_ERRORLOG}: $!");
   }
 }
 
@@ -241,7 +241,8 @@ sub watch_files {
           quoteHighBit => 1,
         );
         my $v = $d->stringify($File::Find::name);
-        warn sprintf qq{Found a bad directory v[%s], rmtree-ing}, $v;
+
+        $Logger->log([ qq{Found a bad directory v[%s], rmtree-ing}, $v ]);
         require File::Path;
         File::Path::rmtree($File::Find::name);
       }
@@ -649,7 +650,10 @@ sub mailrc {
         require Text::Unidecode;
         $r[1] = Text::Unidecode::unidecode($r[1]);
       };
-      warn $@ if $@;
+
+      if ($@) {
+        $Logger->log([ "error unidecoding: %s", "$@" ]);
+      }
     }
     $r[1] =~ s/["<>]//g;
     push @list, sprintf qq{alias %-10s "%s <%s>"\n}, @r[ 0 .. 2 ];

--- a/cron/gmls-lR.pl
+++ b/cron/gmls-lR.pl
@@ -27,13 +27,13 @@ use PAUSE::Logger '$Logger' => { init => {
   facility  => 'daemon',
 } };
 
-chdir $PAUSE::Config->{FTPPUB} or die "Could not chdir to $PAUSE::Config->{FTPPUB}: $!";
+chdir $PAUSE::Config->{FTPPUB}
+  or die "Could not chdir to $PAUSE::Config->{FTPPUB}: $!";
+
 mkdir "indexes", 0755 unless -d "indexes";
 
 for my $dir (qw(authors modules)) {
     chdir $dir or die;
-
-#    system qq(ls -lgR > ../indexes/.$dir.ls-lR);
 
     # find goes depth first algorithm, we need breadth first
     use File::Find;
@@ -41,37 +41,35 @@ for my $dir (qw(authors modules)) {
     open FH, ">../indexes/.$dir.ls-lR" or die;
     my %seen;
     find(sub {
-	     return if $seen{$File::Find::dir}++;
-	     my $ffdir = $File::Find::dir;
-	     $ffdir =~ s|^./?||;
-	     print FH "\n\n$ffdir\:\n" if $ffdir;
-	     print FH "total 123456789\n";
-	     local *DIR;
-	     opendir DIR, "." or die "Couldn't open . [=$ffdir]: $!";
-	     my @dir = sort readdir DIR;
-	     closedir DIR;
-	     for my $dirent (@dir) {
-		 next if substr($dirent,0,1) eq ".";
-		 print FH gmls($dirent);
-	     }
-	     print FH "\n\n";
-	 }, "." );
+             return if $seen{$File::Find::dir}++;
+             my $ffdir = $File::Find::dir;
+             $ffdir =~ s|^./?||;
+             print FH "\n\n$ffdir\:\n" if $ffdir;
+             print FH "total 123456789\n";
+             local *DIR;
+             opendir DIR, "." or die "Couldn't open . [=$ffdir]: $!";
+             my @dir = sort readdir DIR;
+             closedir DIR;
+             for my $dirent (@dir) {
+                 next if substr($dirent,0,1) eq ".";
+                 print FH gmls($dirent);
+             }
+             print FH "\n\n";
+         }, "." );
 
     close FH;
     chdir "../indexes";
-#    system(qq(gzip -c9 < .$dir.ls-lR > .$dir.ls-lR.gz))==0 or
-# 	rename ".$dir.ls-lR.gz", ".$dir.ls-lR.gz.error";
 
     if (
-	-f ".$dir.ls-lR"
-	&&
-	(
-	 ! -f "$dir.ls-lR"
-	 or
-	 compare("$dir.ls-lR", ".$dir.ls-lR")
-	)
-	&&
-	system(qq(gzip -c9 < .$dir.ls-lR > .$dir.ls-lR.gz))==0
+        -f ".$dir.ls-lR"
+        &&
+        (
+         ! -f "$dir.ls-lR"
+         or
+         compare("$dir.ls-lR", ".$dir.ls-lR")
+        )
+        &&
+        system(qq(gzip -c9 < .$dir.ls-lR > .$dir.ls-lR.gz))==0
        ) {
       rename ".$dir.ls-lR", "$dir.ls-lR";
       rename ".$dir.ls-lR.gz", "$dir.ls-lR.gz";
@@ -88,9 +86,9 @@ sub gmls {
     my $pname = $name;
 
     if ($blocks) {
-	$blocks = int(($blocks + 1) / 2);
+        $blocks = int(($blocks + 1) / 2);
     } else {
-	$blocks = int(($sizemm + 1023) / 1024);
+        $blocks = int(($sizemm + 1023) / 1024);
     }
 
     if    (-f _) { $perms = '-'; }
@@ -120,20 +118,20 @@ sub gmls {
     my($timeyear);
     my($moname) = $moname[$mon];
     if (-M _ > 365.25 / 2) {
-	$timeyear = $year + 1900;
+        $timeyear = $year + 1900;
     }
     else {
-	$timeyear = sprintf("%02d:%02d", $hour, $min);
+        $timeyear = sprintf("%02d:%02d", $hour, $min);
     }
 
     sprintf "%-10s %2d %-3s %8s %s %2d %5s %s\n",
-	      $perms,
-		    $nlink,
-		       $user,
-			    $sizemm,
-			        $moname,
-				    $mday,
-				        $timeyear,
-					    $pname;
+              $perms,
+                    $nlink,
+                       $user,
+                            $sizemm,
+                                $moname,
+                                    $mday,
+                                        $timeyear,
+                                            $pname;
 }
 

--- a/cron/rm_stale_links
+++ b/cron/rm_stale_links
@@ -41,39 +41,40 @@ my %KEEP_FOREVER = (
 );
 
 find(
-     {
-      bydepth => 1,
-      wanted => sub {
-        return if /^\.\.?$/;
-        return if $KEEP_FOREVER{ $File::Find::name };
-        my($dev,$ino,$mode,$nlink,$uid,$gid) = lstat($_);
-        if (-l $_ && ! -e $_){
-          $Logger->log("unlinking stale $File::Find::name");
-          unlink $_;
-          # PAUSE::delfile_hook(File::Spec->rel2abs($_)); # do we track symlinks?
+  {
+    bydepth => 1,
+    wanted => sub {
+      return if /^\.\.?$/;
+      return if $KEEP_FOREVER{ $File::Find::name };
+      my($dev,$ino,$mode,$nlink,$uid,$gid) = lstat($_);
+      if (-l $_ && ! -e $_){
+        $Logger->log("unlinking stale $File::Find::name");
+        unlink $_;
+        # PAUSE::delfile_hook(File::Spec->rel2abs($_)); # do we track symlinks?
+      }
+      if ($_ eq "CHECKSUMS") {
+        opendir DIR, ".";
+        my @readdir = readdir DIR;
+        closedir DIR;
+        if (@readdir == 3) {
+          $Logger->log("unlinking orphaned $File::Find::name");
+          unlink $_ or die "Could not unlink $_: $!";
+          PAUSE::delfile_hook(File::Spec->rel2abs($_)); # definitely needed
         }
-        if ($_ eq "CHECKSUMS") {
-          opendir DIR, ".";
-          my @readdir = readdir DIR;
-          closedir DIR;
-          if (@readdir == 3) {
-            $Logger->log("unlinking orphaned $File::Find::name");
-            unlink $_ or die "Could not unlink $_: $!";
-            PAUSE::delfile_hook(File::Spec->rel2abs($_)); # definitely needed
-          }
+      }
+      return if -l $_;
+      ($dev,$ino,$mode,$nlink,$uid,$gid) = stat($_);
+      if (-d _ and $nlink == 2) { # directory without subdir
+        opendir DIR, $_;
+        my @readdir = readdir DIR;
+        closedir DIR;
+        if (@readdir == 2) {
+          $Logger->log("rmdirring empty $File::Find::name");
+          rmdir $_ or die "Could not rmdir $_: $!";
+          # PAUSE::delfile_hook(File::Spec->rel2abs($_)); # we do not track directories
         }
-        return if -l $_;
-        ($dev,$ino,$mode,$nlink,$uid,$gid) = stat($_);
-        if (-d _ and $nlink == 2) { # directory without subdir
-          opendir DIR, $_;
-          my @readdir = readdir DIR;
-          closedir DIR;
-          if (@readdir == 2) {
-            $Logger->log("rmdirring empty $File::Find::name");
-            rmdir $_ or die "Could not rmdir $_: $!";
-            # PAUSE::delfile_hook(File::Spec->rel2abs($_)); # we do not track directories
-          }
-        }
-      },
-     },
-     "authors", "modules");
+      }
+    },
+  },
+  "authors", "modules"
+);

--- a/cron/rm_stale_links
+++ b/cron/rm_stale_links
@@ -48,7 +48,7 @@ find(
         return if $KEEP_FOREVER{ $File::Find::name };
         my($dev,$ino,$mode,$nlink,$uid,$gid) = lstat($_);
         if (-l $_ && ! -e $_){
-          warn "unlinking stale $File::Find::name\n";
+          $Logger->log("unlinking stale $File::Find::name");
           unlink $_;
           # PAUSE::delfile_hook(File::Spec->rel2abs($_)); # do we track symlinks?
         }
@@ -57,7 +57,7 @@ find(
           my @readdir = readdir DIR;
           closedir DIR;
           if (@readdir == 3) {
-            warn "unlinking orphaned $File::Find::name\n";
+            $Logger->log("unlinking orphaned $File::Find::name");
             unlink $_ or die "Could not unlink $_: $!";
             PAUSE::delfile_hook(File::Spec->rel2abs($_)); # definitely needed
           }
@@ -69,7 +69,7 @@ find(
           my @readdir = readdir DIR;
           closedir DIR;
           if (@readdir == 2) {
-            warn "rmdirring empty $File::Find::name\n";
+            $Logger->log("rmdirring empty $File::Find::name");
             rmdir $_ or die "Could not rmdir $_: $!";
             # PAUSE::delfile_hook(File::Spec->rel2abs($_)); # we do not track directories
           }

--- a/cron/update-checksums.pl
+++ b/cron/update-checksums.pl
@@ -88,8 +88,10 @@ use PAUSE ();
 
 $Opt{debug} ||= 0;
 if ($Opt{debug}) {
-  warn "Debugging on. CPAN::Checksums::VERSION[$CPAN::Checksums::VERSION]";
+  $Logger->set_debug(1);
+  $Logger->log("Debugging on. CPAN::Checksums::VERSION[$CPAN::Checksums::VERSION]");
 }
+
 my $root = $PAUSE::Config->{MLROOT};
 $Opt{startdir} //= $root;
 our $TESTDIR;
@@ -159,7 +161,7 @@ find(sub {
        }
        my $ret = eval { CPAN::Checksums::updatedir($ffname, $root); };
        if ($@) {
-         warn "error[$@] in checksums file[$ffname]: must unlink";
+         $Logger->log("error[$@] in checksums file[$ffname]: must unlink");
          unlink "$ffname/CHECKSUMS";
        }
        if ($Opt{debug}) {
@@ -175,7 +177,14 @@ find(sub {
            ) or die $!;
          $yaml->{stop} = time;
          my $tooktime = sprintf "%.6f", $yaml->{stop} - $yaml->{start};
-         warn "debugdir[$debugdir]ret[$ret]tooktime[$tooktime]cnt[$cnt]\n";
+
+         $Logger->log_event('checksum-debugging-file' => [
+           debugdir => $debugdir,
+           ret      => $ret,
+           tooktime => $tooktime,
+           cnt      => $cnt,
+         ]);
+
          $yaml->{tooktime} = $tooktime;
          YAML::Syck::DumpFile(File::Spec->catfile($debugdir,
                                                   "YAML"), $yaml);


### PR DESCRIPTION
Now that the cron jobs are all(?) successfully loading PAUSE::Logger, we should use it.  This replaces "warn" calls with use of $Logger.