### PR TITLE
reduce mldistwatch log noise, and use constants (for errors

### DIFF
--- a/lib/PAUSE/dist.pm
+++ b/lib/PAUSE/dist.pm
@@ -30,15 +30,15 @@ sub ignoredist {
   my $self = shift;
   my $dist = $self->{DIST};
   if ($dist =~ m|/\.|) {
-    $Logger->log("Warning: illegal filename");
-    return 1;
+    return PAUSE::mldistwatch::Constants::IGFILENAME;
   }
 
-  return 1 if $dist =~ /(\.readme|\.sig|\.meta|CHECKSUMS)$/;
+  return PAUSE::mldistwatch::Constants::IGMETADATA
+    if $dist =~ /(\.readme|\.sig|\.meta|CHECKSUMS)$/;
 
   # Stupid to have code that needs to be maintained in two places,
   # here and in edit.pm:
-  return "weird CNANDOR case"
+  return PAUSE::mldistwatch::Constants::IGCNANDOR
     if $dist =~ m!CNANDOR/(?:mp_(?:app|debug|doc|lib|source|tool)|VISEICat(?:\.idx)?|VISEData)!;
 
   return;

--- a/lib/PAUSE/mldistwatch.pm
+++ b/lib/PAUSE/mldistwatch.pm
@@ -102,7 +102,6 @@ sub new {
                       OPT => $opt,
                       PIDFH => $fh,
                      }, $class;
-    $self->{VERBOSE} = -t STDOUT ? 2 : 1;
     if ($opt->{pick}) {
         for my $pick (@{$opt->{pick}}) {
             $pick =~ s|^.*authors/id/|| if $pick =~ m|authors/id/./../|;

--- a/lib/PAUSE/mldistwatch/Constants.pm
+++ b/lib/PAUSE/mldistwatch/Constants.pm
@@ -49,6 +49,14 @@ sub heading ($) {
   $heading->{$status};
 }
 
+# constants used for ignoredist
+use constant IGFILENAME => 'illegal filename';
+use constant IGMETADATA => 'metadata';
+use constant IGCNANDOR => 'weird CNANDOR case';
+use constant IGGONER => "it's a goner";
+use constant IGNOLOCK => 'could not obtain a lock';
+use constant IGUNCHANGED => 'file mtime has not changed';
+
 1;
 
 

--- a/t/lib/PAUSE/TestPAUSE.pm
+++ b/t/lib/PAUSE/TestPAUSE.pm
@@ -269,7 +269,7 @@ sub _build_pause_config_overrides {
 
   {
     my $chdir_guard = pushd($git_dir);
-    system(qw(git init)) and die "error running git init";
+    system(qw(git init --initial-branch master)) and die "error running git init";
 
     my $git_config = File::Spec->catdir($git_dir, '.git/config');
     open my $config_fh, '>', $git_config


### PR DESCRIPTION
Primarily

    Use a set of constant enums for when mldistwatch decides to ignore a dist.
    
    - The actual values are the same, where possible.  Some values were just '1'
      which has been made more specific.
    - These are only used in one place.
    - Now we can easily route the log lines for metadata and readme files to the
      debug log


But also a few other cleanups.