### PR TITLE
mldistwatch: fix logging for uninteresting files

### DIFF
--- a/lib/PAUSE/dist.pm
+++ b/lib/PAUSE/dist.pm
@@ -34,7 +34,7 @@ sub ignoredist {
     return 1;
   }
 
-  return 1 if $dist =~ /(\.readme|\.sig|\.meta|CHECKSUMS)$/;
+  return "non-dist file" if $dist =~ /(\.readme|\.sig|\.meta|CHECKSUMS)$/;
 
   # Stupid to have code that needs to be maintained in two places,
   # here and in edit.pm:

--- a/lib/PAUSE/mldistwatch.pm
+++ b/lib/PAUSE/mldistwatch.pm
@@ -437,9 +437,11 @@ sub maybe_index_dist {
     local $Logger = $Logger->proxy({ proxy_prefix => "$dist: " });
 
     if (my $skip_reason = $self->reason_to_skip_dist($dio)) {
-        # We don't log on $OLD_UNCHANGED_FILE because it's extremely common and
-        # leads to noise in the logs. -- rjbs, 2024-04-28
-        my $log_method = $skip_reason eq $OLD_UNCHANGED_FILE ? 'log_debug' : 'log';
+        # We don't log on a few things that are extremely common and lead to
+        # noise in the logs. -- rjbs, 2024-04-28
+        my $log_method = $skip_reason eq $OLD_UNCHANGED_FILE ? 'log_debug'
+                       : $skip_reason eq "non-dist file"     ? 'log_debug'
+                       :                                       'log';
         $Logger->$log_method("skipping: $skip_reason");
 
         delete $self->{ALLlasttime}{$dist};


### PR DESCRIPTION
First, "1" is not a reason.  Return a string.

Secondly, do not log this string by default.  It is boring.

This is substandard work, but further work will just complicate the PAUSE::Indexer::Context work, which will make fixing this in a really nice way easy!

This is an alternative to #498