### PR TITLE
Explicitly set a default branch when initializing the test git repo.

### DIFF
--- a/t/lib/PAUSE/TestPAUSE.pm
+++ b/t/lib/PAUSE/TestPAUSE.pm
@@ -269,7 +269,7 @@ sub _build_pause_config_overrides {
 
   {
     my $chdir_guard = pushd($git_dir);
-    system(qw(git init)) and die "error running git init";
+    system(qw(git init --initial-branch master)) and die "error running git init";
 
     my $git_config = File::Spec->catdir($git_dir, '.git/config');
     open my $config_fh, '>', $git_config


### PR DESCRIPTION
This avoid git printng out a ~10 line warning, which clutters the output.

Do not merge until Perl/docker-perl-tester#62 is merged and deployed.  These flags do not work on buster, so we need a bookworm image to run on. 