### PR TITLE
webui: eliminate descriptions of SQL in web interface

### DIFF
--- a/lib/pause_2017/templates/public/admin.html.ep
+++ b/lib/pause_2017/templates/public/admin.html.ep
@@ -1,7 +1,6 @@
 % layout 'layout';
 % my $pause = stash(".pause") || {};
 
-<p>Query the <code>grouptable</code> table for who is an admin bit holder</p>
 <p>Registered admins: <%= join ", ", @{$pause->{admins} || []} %></p>
 <p><a href="<%= my_url->query(ACTION => "who_admin", OF => "YAML") %>" style="text-decoration: none;">
 <span class="orange_button">YAML</span>

--- a/lib/pause_2017/templates/public/pumpkin.html.ep
+++ b/lib/pause_2017/templates/public/pumpkin.html.ep
@@ -1,7 +1,6 @@
 % layout 'layout';
 % my $pause = stash(".pause") || {};
 
-<p>Query the <code>grouptable</code> table for who is a pumpkin bit holder</p>
 <p>Registered pumpkins: <%= join ", ", @{$pause->{pumpkins} || []} %></p>
 <p><a href="<%= my_url->query(ACTION => "who_pumpkin", OF => "YAML") %>" style="text-decoration: none;">
 <span class="orange_button">YAML</span>

--- a/lib/pause_2017/templates/user/distperms/peek.html.ep
+++ b/lib/pause_2017/templates/user/distperms/peek.html.ep
@@ -1,12 +1,6 @@
 % layout 'layout';
 % my $pause = stash(".pause") || {};
 
-<p>Query the <code>perms</code> table by author or by
-distribution. Select the option and fill in a distribution name or
-user ID as appropriate. The answer is all distributions that an
-user ID is registered for or all user IDs registered for a
-distribution, as appropriate.</p>
-
 <p>Registration comes in one of two types: type
 <b>first-come</b> is the automatic registration on a
 first-come-first-serve basis that happens on the initial

--- a/lib/pause_2017/templates/user/perms/peek.html.ep
+++ b/lib/pause_2017/templates/user/perms/peek.html.ep
@@ -1,12 +1,6 @@
 % layout 'layout';
 % my $pause = stash(".pause") || {};
 
-<p>Query the <code>perms</code> table by author or by
-module. Select the option and fill in a module name or
-user ID as appropriate. The answer is all modules that an
-user ID is registered for or all user IDs registered for a
-module, as appropriate.</p>
-
 <p>Registration comes in one of two types: type
 <b>first-come</b> is the automatic registration on a
 first-come-first-serve basis that happens on the initial


### PR DESCRIPTION
I think it's weird for the UI to describe the tables it will query. Users will want to know what information they're getting, but not how it's laid out in the database.