### PR TITLE
Upgrade to actions/checkout@v4

### DIFF
--- a/.github/workflows/perl-tests.yml
+++ b/.github/workflows/perl-tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Makefile.PL
         run: |
           perl Makefile.PL && make


### PR DESCRIPTION
Fixes this warning:
> Node.js 16 actions are deprecated.  Please update the following actions to
> use Node.js 20: actions/checkout@v3.  For more information see:
> https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.