### PR TITLE
tests: quiet noise from verbosely run tests

### DIFF
--- a/t/lib/PAUSE/TestPAUSE.pm
+++ b/t/lib/PAUSE/TestPAUSE.pm
@@ -269,7 +269,7 @@ sub _build_pause_config_overrides {
 
   {
     my $chdir_guard = pushd($git_dir);
-    system(qw(git init --initial-branch master)) and die "error running git init";
+    system(qw(git init --quiet --initial-branch master)) and die "error running git init";
 
     my $git_config = File::Spec->catdir($git_dir, '.git/config');
     open my $config_fh, '>', $git_config

--- a/t/lib/PAUSE/TestPAUSE.pm
+++ b/t/lib/PAUSE/TestPAUSE.pm
@@ -387,8 +387,11 @@ sub file_updated_ok {
 
   local $Test::Builder::Level = $Test::Builder::Level + 1;
 
+  my $tmpdir = $self->tmpdir . "";
+  my $prettyname = $filename =~ s/\Q$tmpdir/\${TEST}/r;
+
   unless (-e $filename) {
-    return Test::More::fail("$desc$filename not updated");
+    return Test::More::fail("$desc$prettyname not updated");
   }
 
   my ($dev, $ino) = stat $filename;
@@ -397,12 +400,12 @@ sub file_updated_ok {
 
   unless (defined $old) {
     $self->_file_index->{$filename} = "$dev,$ino";
-    return Test::More::pass("$desc$filename updated (created)");
+    return Test::More::pass("$desc$prettyname updated (created)");
   }
 
   my $ok = Test::More::ok(
     $old ne "$dev,$ino",
-    "$desc$filename updated",
+    "$desc$prettyname updated",
   );
 
   $self->_file_index->{$filename} = "$dev,$ino";
@@ -417,21 +420,24 @@ sub file_not_updated_ok {
 
   my $old = $self->_file_index->{ $filename };
 
+  my $tmpdir = $self->tmpdir . "";
+  my $prettyname = $filename =~ s/\Q$tmpdir/\${TEST}/r;
+
   unless (-e $filename) {
-    return Test::More::fail("$desc$filename deleted") if $old;
-    return Test::More::pass("$desc$filename not created (thus not updated)");
+    return Test::More::fail("$desc$prettyname deleted") if $old;
+    return Test::More::pass("$desc$prettyname not created (thus not updated)");
   }
 
   my ($dev, $ino) = stat $filename;
 
   unless (defined $old) {
     $self->_file_index->{$filename} = "$dev,$ino";
-    return Test::More::fail("$desc$filename updated (created)");
+    return Test::More::fail("$desc$prettyname updated (created)");
   }
 
   my $ok = Test::More::ok(
     $old eq "$dev,$ino",
-    "$desc$filename not updated",
+    "$desc$prettyname not updated",
   );
 
   return $ok;


### PR DESCRIPTION
This really only affects the indexer tests but:

1. do not print "initializing git repo" for every single new TestPAUSE
2. when printing out whether files changed, replace the long tmpdir path with `${TEST}` to reduce clutter

(The path will be gone, so seeing it isn't useful.  If you need to work with the results, you can call `$testpause->run_shell` in the tests.)