### PR TITLE
GitHub Action improvements, including coverage tests! 

### DIFF
--- a/.github/workflows/perl-tests.yml
+++ b/.github/workflows/perl-tests.yml
@@ -8,6 +8,15 @@ on:
     - reopened
     - labeled
 
+#
+# * To trigger a coverage run, add the `want-coverage` label, and
+# cover will be used instead of prove.  Results will be posted to
+# https://coveralls.io/github/andk/pause
+#
+# * To flush the GitHub Actions Cache:
+# https://github.com/andk/pause/actions/caches
+#
+
 jobs:
   the-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/perl-tests.yml
+++ b/.github/workflows/perl-tests.yml
@@ -1,5 +1,12 @@
 name: "perl test suite"
-on: [ push, pull_request ]
+on:
+  push:
+  pull_request:
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - labeled
 
 jobs:
   the-tests:
@@ -36,7 +43,15 @@ jobs:
         # may do that later, but for now, it's fine! -- rjbs, 2023-01-07
         run: cpanm --notest --installdeps .
       - name: Run the tests
+        if: "!(contains(github.event.pull_request.labels.*.name, 'want-coverage'))"
         run: prove -lr -j4 t
+      - name: Run tests (with coverage)
+        if: contains(github.event.pull_request.labels.*.name, 'want-coverage')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cpanm -n Devel::Cover::Report::Coveralls
+          cover -test -report Coveralls
 #      - name: Install yath and JUnit renderer
 #        run: cpanm --notest Test2::Harness Test2::Harness::Renderer::JUnit
 #      - name: Run the tests
@@ -52,4 +67,3 @@ jobs:
 #        with:
 #          check_name: JUnit Report
 #          report_paths: /tmp/test-output.xml
-

--- a/.github/workflows/perl-tests.yml
+++ b/.github/workflows/perl-tests.yml
@@ -30,6 +30,17 @@ jobs:
         run: |
           apt update
           apt install -y rsync default-mysql-server
+      - name: Get Perl Version
+        id: get-perl-version
+        run: |
+          echo version="$(perl -le 'print $]')" >> $GITHUB_OUTPUT
+        shell: bash
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            /usr/local/lib/perl5/site_perl
+          key: ${{ runner.os }}-${{ steps.get-perl-version.outputs.version }}-${{ hashFiles('Makefile.PL') }}
       - name: Install prereqs (cpan)
         # This could probably be made more efficient by looking at what it's
         # installing via cpanm that could, instead, be installed from apt.  I

--- a/.github/workflows/perl-tests.yml
+++ b/.github/workflows/perl-tests.yml
@@ -30,13 +30,6 @@ jobs:
         run: |
           apt update
           apt install -y rsync default-mysql-server
-      - name: Install prereqs (cpanm, pinned versions)
-        # PAUSE is run (for now?) on v5.16, and the latest versions from the
-        # CPAN don't install on v5.16, so we install these version that do.
-        # -- rjbs, 2023-05-05
-        run: |
-          cpanm Log::Dispatchouli@2.023
-          cpanm Mojolicious@8.73
       - name: Install prereqs (cpan)
         # This could probably be made more efficient by looking at what it's
         # installing via cpanm that could, instead, be installed from apt.  I

--- a/.github/workflows/perl-tests.yml
+++ b/.github/workflows/perl-tests.yml
@@ -1,4 +1,4 @@
-name: "perl test suite"
+name: "PAUSE test suite"
 on:
   push:
   pull_request:

--- a/.github/workflows/perl-tests.yml
+++ b/.github/workflows/perl-tests.yml
@@ -22,11 +22,6 @@ jobs:
         run: |
           perl Makefile.PL && make
       - name: Install prereqs (apt)
-        # If we install "default-mysql-server", the web tests will run, which
-        # is good, but they will run forever when we get to
-        # t/pause_2017/action/change_passwd.t not responding to SIGTERM or
-        # SIGKILL.  I seem to recall something about signals being weird on
-        # Actions, but not how... -- rjbs, 2023-05-05
         run: |
           apt update
           apt install -y rsync default-mysql-server

--- a/.github/workflows/perl-tests.yml
+++ b/.github/workflows/perl-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install prereqs (apt)
         run: |
           apt update
-          apt install -y rsync default-mysql-server
+          apt install -y rsync mariadb-server
       - name: Get Perl Version
         id: get-perl-version
         run: |

--- a/.github/workflows/perl-tests.yml
+++ b/.github/workflows/perl-tests.yml
@@ -59,7 +59,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cpanm -n Devel::Cover::Report::Coveralls
-          cover -test -report Coveralls
+          cover -test -report Coveralls | tee -a $GITHUB_STEP_SUMMARY
 #      - name: Install yath and JUnit renderer
 #        run: cpanm --notest Test2::Harness Test2::Harness::Renderer::JUnit
 #      - name: Run the tests

--- a/bootstrap/selfconfig-root
+++ b/bootstrap/selfconfig-root
@@ -169,7 +169,7 @@ run_cmd(qw(ln -s /data/mysql/mysql /var/lib/mysql));
 run_cmd(qw(apt-get -o DPkg::Lock::Timeout=60 install -y),
         qw(
             mariadb-server
-            default-libmysqlclient-dev
+            libmariadb-dev-compat
         ));
 
 # Configure Mariadb a bit


### PR DESCRIPTION
Various cleanups of obsolete things from the workflow.
Caching so we don't have to install modules each time (saves 2 minutes)
Run Devel::Cover coverage tests and push results to Coveralls if the want-coverage label is applied.
Explicitly use MariaDB, instead of whatever Debian's default is.

Same as #508, but going to merge without rebase.