### PR TITLE
tests: switch to slim-bookworm base image

### DIFF
--- a/.github/workflows/perl-tests.yml
+++ b/.github/workflows/perl-tests.yml
@@ -33,7 +33,16 @@ jobs:
       - name: Install prereqs (apt)
         run: |
           apt update
-          apt install -y rsync mariadb-server
+          apt install -y \
+            gnupg \
+            libdb-dev \
+            libexpat-dev \
+            libmariadb-dev-compat \
+            libxml2-dev \
+            mariadb-server \
+            nodejs \
+            rsync \
+            zip
       - name: Get Perl Version
         id: get-perl-version
         run: |

--- a/.github/workflows/perl-tests.yml
+++ b/.github/workflows/perl-tests.yml
@@ -21,7 +21,7 @@ jobs:
   the-tests:
     runs-on: ubuntu-latest
     container:
-      image: perldocker/perl-tester:5.36-bookworm
+      image: perldocker/perl-tester:5.36-slim-bookworm
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/perl-tests.yml
+++ b/.github/workflows/perl-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install prereqs (apt)
         run: |
           apt update
-          apt install -y \
+          apt-get install -y \
             gnupg \
             libdb-dev \
             libexpat-dev \


### PR DESCRIPTION
The slim-bookworm base image (https://github.com/Perl/docker-perl-tester/pull/66) shrinks the image size from 1.6GB to 570GB, and reduces container initialization time by 80%.  (from 45sec to 12sec.)

Because the slim container doesn't have all the batteries included, we need to add some more packages to facilitate a few modules:
gnupg for Module::Signature
libdb-dev for DB_File
libexpat-dev for XML::parser
zip for unzip
nodejs for actions/cache