### PR TITLE
tests: save plack logs to a file.

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,17 @@
+# GitHub Actions Workflows
+
+This directory contains workflow definitions for GitHub actions.
+
+## Local Testing
+
+The easiest way to end to end test them is wih a tool such as
+https://github.com/nektos/act (https://nektosact.com/).
+
+```
+$ act --artifact-server-path=/tmp/artifacts
+... actions run here! ...
+```
+
+You can use the `--reuse` flag to reuse information between runs,
+which can speed things up.  `--action-offline-mode` and `--pull=false`
+can be used to test local copies of container images instead.

--- a/.github/workflows/perl-tests.yml
+++ b/.github/workflows/perl-tests.yml
@@ -24,6 +24,8 @@ jobs:
       image: perldocker/perl-tester:5.36-slim-bookworm
     strategy:
       fail-fast: false
+    env:
+      PLACK_ENV: ghaction
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
@@ -62,6 +64,7 @@ jobs:
       - name: Run the tests
         if: "!(contains(github.event.pull_request.labels.*.name, 'want-coverage'))"
         run: prove -lr -j4 t
+        continue-on-error: true
       - name: Run tests (with coverage)
         if: contains(github.event.pull_request.labels.*.name, 'want-coverage')
         env:
@@ -69,6 +72,23 @@ jobs:
         run: |
           cpanm -n Devel::Cover::Report::Coveralls
           cover -test -report Coveralls | tee -a $GITHUB_STEP_SUMMARY
+        continue-on-error: true
+      # We need different versions of upload-artifact in production or
+      # local testing due to https://github.com/nektos/act/issues/2135
+      - name: Archive plack logs (prod)
+        uses: actions/upload-artifact@v4
+        if: ${{ env.ACT != 'true' }}
+        with:
+          name: plack.log
+          path: |
+            /tmp/plack.log
+      - name: Archive plack logs (dev)
+        uses: actions/upload-artifact@v3
+        if: ${{ env.ACT == 'true' }}
+        with:
+          name: plack.log
+          path: |
+            /tmp/plack.log
 #      - name: Install yath and JUnit renderer
 #        run: cpanm --notest Test2::Harness Test2::Harness::Renderer::JUnit
 #      - name: Run the tests

--- a/etc/plack_log.conf.ghaction
+++ b/etc/plack_log.conf.ghaction
@@ -1,0 +1,7 @@
+dispatchers = file
+
+file.class = Log::Dispatch::File
+file.min_level = debug
+file.format = [%d{%Y-%m-%d %H:%M:%S}] [%p] %m%n
+file.filename = "/tmp/plack.log"
+file.mode = ">>"


### PR DESCRIPTION
Save the plack logs from tests to a file, and then upload that file as an artifact. This significantly quiets/shortens the output from the tests.

Implement by creating a new plack log environment config `ghaction`.