### PR TITLE
actions: Remove upload-artifact@v3 hack.

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,3 +15,6 @@ $ act --artifact-server-path=/tmp/artifacts
 You can use the `--reuse` flag to reuse information between runs,
 which can speed things up.  `--action-offline-mode` and `--pull=false`
 can be used to test local copies of container images instead.
+
+IMPORTANT: You need a version of act from 2024-05-20 or later.
+(e.g. newer than v0.2.62) to support `actions/upload-artifact@v4`.

--- a/.github/workflows/perl-tests.yml
+++ b/.github/workflows/perl-tests.yml
@@ -73,18 +73,8 @@ jobs:
           cpanm -n Devel::Cover::Report::Coveralls
           cover -test -report Coveralls | tee -a $GITHUB_STEP_SUMMARY
         continue-on-error: true
-      # We need different versions of upload-artifact in production or
-      # local testing due to https://github.com/nektos/act/issues/2135
-      - name: Archive plack logs (prod)
+      - name: Upload Artifacts
         uses: actions/upload-artifact@v4
-        if: ${{ env.ACT != 'true' }}
-        with:
-          name: plack.log
-          path: |
-            /tmp/plack.log
-      - name: Archive plack logs (dev)
-        uses: actions/upload-artifact@v3
-        if: ${{ env.ACT == 'true' }}
         with:
           name: plack.log
           path: |


### PR DESCRIPTION
Act now supports upload-artifact@v4, so we don't need to special case that in testing.