### PR TITLE
Do not index Local:: namespace (nor Local)

### DIFF
--- a/lib/PAUSE/pmfile.pm
+++ b/lib/PAUSE/pmfile.pm
@@ -280,6 +280,8 @@ sub packages_per_pmfile {
             next PLINE unless $pkg =~ /^[A-Za-z]/;
             next PLINE unless $pkg =~ /\w$/;
             next PLINE if $pkg eq "main";
+            next PLINE if $pkg =~ /^Local::/; # Local::*
+            next PLINE if $pkg eq "Local"; # Local
             # Perl::Critic::Policy::TestingAndDebugging::ProhibitShebangWarningsArg
             # database for modid in mods, package in packages, package in perms
             # alter table mods modify modid varchar(128) binary NOT NULL default '';


### PR DESCRIPTION
The `Local::` namespace is advertised as "reserved" and "not conflicting", encouraging people to use it to protect from inadvertently installing public modules. But currently, Local:: namespace can be indexed, like any other namespace. In the scope of CPAN Security, I propose this change to avoid indexing Local::

Please find below the proof of testing of this change:

![pause-no-local](https://github.com/user-attachments/assets/3f5fef14-e603-4787-888c-48b4b18a2834)

![pause-no-local-log](https://github.com/user-attachments/assets/5b9af844-2a5c-489d-ae4b-b5bf73ef0108)

![pause-no-local-db](https://github.com/user-attachments/assets/b4df153e-d930-410b-a4ee-f12ff9b134c6)

Along with this change, we should ideally cleanup the index from any Local:: module (but keep `local::lib`)

## Official documentation
The PAUSE documentation [On The Naming of Modules](https://pause.perl.org/pause/query?ACTION=pause_namingmodules#Local) says:
> By convention, the top-level Local namespace should never conflict with anything on CPAN. This allows you to be confident that the name you choose under Local isn't going to conflict with anything from the outside world.

[The Perl Module Library (perlmodlib)](https://perldoc.perl.org/perlmodlib#Guidelines-for-Module-Creation) goes further with:
> If developing modules for private internal or project specific use, that will never be released to the public, then you should ensure that their names will not clash with any future public module. You can do this either by using the reserved Local::* category or by using a category name that includes an underscore like Foo_Corp::*.

## More references
- [Avoid CPAN conflicts in your personal Perl modules (Mark Gardner)](https://markjgardner.medium.com/avoid-cpan-conflicts-in-your-personal-perl-modules-736f79971ddc)
- [Namespace for local/internal modules? (PerlMonks)](https://www.perlmonks.org/?node_id=972123)
- [Best practices for local libraries (PerlMonks)](https://www.perlmonks.org/index.pl?node_id=11109789)