### PR TITLE
GET URL: HTTPS is now supported

### DIFF
--- a/lib/pause_2017/templates/user/uri/add.html.ep
+++ b/lib/pause_2017/templates/user/uri/add.html.ep
@@ -56,8 +56,7 @@ you do not seem to want HTTP upload enabled, we do
 % }
 
 <p class="url_upload"><b>GET URL:</b> PAUSE fetches any http or ftp
-URL that can be handled by LWP (<b>Note: https is currently not
-supported</b>): use the text field (please specify the <i>complete
+URL that can be handled by LWP: use the text field (please specify the <i>complete
 URL</i>).</p>
 
 <blockquote><b>Please,</b> make sure your filename


### PR DESCRIPTION
# Description 

In short, GET URL supports HTTPS

The note added in commit [a1022e72ae373a7a593317d4d643a58c611d41f0](https://github.com/andk/pause/commit/a1022e72ae373a7a593317d4d643a58c611d41f0) one year ago is no longer true

![pause-get-url-https](https://github.com/user-attachments/assets/070223a7-7995-4a26-83fe-fec1cc7fd06b)
