### PR TITLE
Replace modules@cpan.org with modules@perl.org because the former seems not working

### DIFF
--- a/lib/PAUSE.pm
+++ b/lib/PAUSE.pm
@@ -118,7 +118,7 @@ $PAUSE::Config ||=
      TIMEOUT => 60*60,
      TRUST_IS_SSL_HEADER => 1,
      TMP => '/data/pause/tmp/',
-     UPLOAD => 'upload@pause.perl.org',
+     UPLOAD => 'modules@perl.org',
      # sign the auto-generated CHECKSUM files with:
      CHECKSUMS_SIGNING_PROGRAM => 'gpg',
      CHECKSUMS_SIGNING_ARGS => '-q --homedir /home/pause/pause-private/gnupg-pause-batch-signing-home --clearsign --default-key ',

--- a/lib/pause_2017/templates/user/distperms/remove_dist_primary.html.ep
+++ b/lib/pause_2017/templates/user/distperms/remove_dist_primary.html.ep
@@ -48,7 +48,7 @@ to one of the other owners.</p>
 
 <p class="notice">
 If you have are unsure about what to do, or have any questions,
-please email the PAUSE admins at <a href="mailto:modules@cpan.org">modules@cpan.org</a>.
+please email the PAUSE admins at <a href="mailto:modules@perl.org">modules@perl.org</a>.
 </p>
 
 <p class="notice">If you need finer control (eg. to give up only a small part of

--- a/lib/pause_2017/templates/user/perms/remove_primary.html.ep
+++ b/lib/pause_2017/templates/user/perms/remove_primary.html.ep
@@ -45,7 +45,7 @@ to one of the other owners.</p>
 
 <p class="notice">
 If you have are unsure about what to do, or have any questions,
-please email the PAUSE admins at <a href="mailto:modules@cpan.org">modules@cpan.org</a>.
+please email the PAUSE admins at <a href="mailto:modules@perl.org">modules@perl.org</a>.
 </p>
 
 <p class="notice">If you want to give up all the modules in a distribution, visit


### PR DESCRIPTION
This PR addresses https://github.com/andk/pause/issues/537#issuecomment-2454347813 . The `upload@pause.perl.org` issue is addressed as well, which means this PR should fix #537 .