### PR TITLE
Improve sorting by the modified date

### DIFF
--- a/lib/pause_2017/PAUSE/Web/Controller/User/Files.pm
+++ b/lib/pause_2017/PAUSE/Web/Controller/User/Files.pm
@@ -49,10 +49,11 @@ sub show {
       warn "ALERT: Could not stat f[$f]: $!";
       next;
     }
+    my $modified = (stat _)[9];
     my $blurb = $deletes{$f} ?
         $c->scheduled($whendele{$f}) :
-            HTTP::Date::time2str((stat _)[9]);
-    $files{$f} = {stat => -s _, blurb => $blurb, indexed => $indexed->{$f} };
+            HTTP::Date::time2str($modified);
+    $files{$f} = {stat => -s _, blurb => $blurb, indexed => $indexed->{$f}, modified => $modified };
   }
   $pause->{files} = \%files;
 }
@@ -177,10 +178,11 @@ sub delete {
     $tmpf =~ s/\.(?:readme|meta)$/.tar.gz/;
     my $info = CPAN::DistnameInfo->new($tmpf);
     my $distv = $info->distvname;
+    my $modified = (stat _)[9];
     my $blurb = $deletes{$f} ?
         $c->scheduled($whendele{$f}) :
-            HTTP::Date::time2str((stat _)[9]);
-    $files{$f} = {stat => -s _, blurb => $blurb, indexed => $indexed->{$f}, distv => $distv };
+            HTTP::Date::time2str($modified);
+    $files{$f} = {stat => -s _, blurb => $blurb, indexed => $indexed->{$f}, distv => $distv, modified => $modified };
     $pause->{deleting_indexed_files} = 1 if $deletes{$f} && $indexed->{$f};
   }
   $pause->{files} = \%files;

--- a/lib/pause_2017/templates/user/files/delete.html.ep
+++ b/lib/pause_2017/templates/user/files/delete.html.ep
@@ -36,7 +36,7 @@
       <td class="file"><%= $file %></td>
 %   }
       <td class="size"><%= $files->{$file}{stat} %></td>
-      <td class="modified"><%= $files->{$file}{blurb} %></td>
+      <td class="modified" data-modified="<%= $files->{$file}{modified} %>"><%= $files->{$file}{blurb} %></td>
     </tr>
 % }
   </tbody>
@@ -48,7 +48,7 @@
 %= javascript "/list.min.js"
 %= javascript begin
 var List = new List('files', {
-  valueNames: ['file', 'size', 'modified']
+  valueNames: ['file', 'size', { name: 'modified', attr: 'data-modified' }]
 });
 
 document.querySelectorAll('input[type=checkbox]').forEach(function(e) {

--- a/lib/pause_2017/templates/user/files/show.html.ep
+++ b/lib/pause_2017/templates/user/files/show.html.ep
@@ -23,7 +23,7 @@
       <td class="file"><%= $file %></td>
 %   }
       <td class="size"><%= $files->{$file}{stat} %></td>
-      <td class="modified"><%= $files->{$file}{blurb} %></td>
+      <td class="modified" data-modified="<%= $files->{$file}{modified} %>"><%= $files->{$file}{blurb} %></td>
     </tr>
 %   }
   </tbody>
@@ -33,7 +33,7 @@
 %= javascript "/list.min.js"
 %= javascript begin
 var List = new List('files', {
-  valueNames: ['file', 'size', 'modified']
+  valueNames: ['file', 'size', { name: 'modified', attr: 'data-modified' }]
 });
 % end
 % end


### PR DESCRIPTION
Store raw modified time in a "data-modified" attribute of each "modified" cell and configure list.js to sort by the value, instead of sorting by the blurb value.

should fix #553 .