### PR TITLE
Remove the link to CPAN Mirrors

### DIFF
--- a/htdocs/04pause.html
+++ b/htdocs/04pause.html
@@ -57,9 +57,6 @@ Makefile.PL (or Build.PL), so they can be installed in a standard way.
 
 </blockquote>
 
-<p>Use one of the many <a href="http://www.cpan.org/SITES.html">CPAN Mirrors</a>
-to download from.</p>
-
 <h3><a id="registering" name="registering"></a>Registering as a developer</h3>
 
 <p>Registered developers have a unique username and a home directory in


### PR DESCRIPTION
There is no longer a CPAN Mirror Network.

It is also confusing to have a link that suggests where to download modules from in a section about uploading modules.