### PR TITLE
Switch to object interface for creating tempdirs

### DIFF
--- a/bin/paused
+++ b/bin/paused
@@ -861,7 +861,7 @@ sub verify_gzip_tar {
 sub _rewrite_tarball {
     my($path) = @_;
     $path = File::Spec->rel2abs($path);
-    my $testdir = File::Temp::tempdir(
+    my $testdir = File::Temp->newdir(
                                       "paused_rewrite_XXXX",
                                       DIR => "/tmp",
                                       CLEANUP => 1,


### PR DESCRIPTION
Switch to the object interface for creating temp directories.  This primarily changes their lifetime.  They are now cleaned up when the scope ends, as opposed to when the program exits.

Fixes #533 