### PR TITLE
Speed up query in paused loop.

### DIFF
--- a/bin/paused
+++ b/bin/paused
@@ -201,7 +201,7 @@ sub loop () { # we're NOT called as a method
 	      WHERE length(userid) > 1
                 AND ( dverified=''
                       OR
-                      dverified+0 > ?
+                      dverified > ?
                     ) }; #};
 
   $sth = $dbh->prepare($query);

--- a/doc/mod.schema.txt
+++ b/doc/mod.schema.txt
@@ -292,6 +292,7 @@ CREATE TABLE uris (
   is_perl6 tinyint NOT NULL DEFAULT 0,
   PRIMARY KEY (uriid),
   UNIQUE KEY useridbaseis_perl6 (userid,basename,is_perl6),
+  KEY dverified (dverified),
   KEY uri (uri)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1 PACK_KEYS=1;
 /*!40101 SET character_set_client = @saved_cs_client */;


### PR DESCRIPTION
- Add an index on dverified.
- Stop doing explicit conversion from str to int (dverified + 0)
- dverified will always be a 10 digit unix timestamp, so string comparison results in the same as numeric.
- Query goes from ~30 sec to ~5

(Alternative considered was adding a virtual dverified_num column, but that's a lot more invasive.)