### PR TITLE
Make it easy to extend pause web

### DIFF
--- a/lib/pause_2017/PAUSE/Web.pm
+++ b/lib/pause_2017/PAUSE/Web.pm
@@ -25,10 +25,12 @@ sub startup {
   $app->secrets($app->pause->secrets);
 
   # Fix template path for now
-  unshift @{$app->renderer->paths}, $app->home->rel_file("lib/pause_2017/templates");
+  unshift @{$app->renderer->paths}, map { $app->home->rel_file($_) } @{ $app->pause->template_paths };
 
   # Fix static path
   unshift @{$app->static->paths}, $app->home->rel_file("htdocs");
+
+  $app->routes->namespaces($app->pause->controller_namespaces);
 
   # Load plugins to modify path/set stash values/provide helper methods
   $app->plugin("WithCSRFProtection");

--- a/lib/pause_2017/PAUSE/Web.pm
+++ b/lib/pause_2017/PAUSE/Web.pm
@@ -2,7 +2,6 @@ package PAUSE::Web;
 
 use Mojo::Base "Mojolicious";
 use MojoX::Log::Dispatch::Simple;
-use Digest::SHA1 qw/sha1_hex/;
 
 has pause => sub { Carp::confess "requires PAUSE::Web::Context" };
 
@@ -23,7 +22,7 @@ sub startup {
   $app->hook(around_dispatch => \&_log);
 
   # Set random secrets to keep mojo session secure
-  $app->secrets([sha1_hex($$.time)]);
+  $app->secrets($app->pause->secrets);
 
   # Fix template path for now
   unshift @{$app->renderer->paths}, $app->home->rel_file("lib/pause_2017/templates");

--- a/lib/pause_2017/PAUSE/Web/Context.pm
+++ b/lib/pause_2017/PAUSE/Web/Context.pm
@@ -18,6 +18,8 @@ has root => sub { Carp::confess "requires root" };
 has config => sub { require PAUSE::Web::Config; PAUSE::Web::Config->new };
 has logger => sub { Log::Dispatch::Config->instance };
 has mailer => sub { Email::Sender::Simple->new };
+has template_paths => sub { [ "lib/pause_2017/templates" ] };
+has controller_namespaces => sub { [ "PAUSE::Web::Controller" ] };
 
 sub init {
   my $self = shift;

--- a/lib/pause_2017/PAUSE/Web/Context.pm
+++ b/lib/pause_2017/PAUSE/Web/Context.pm
@@ -9,9 +9,11 @@ use Email::Sender::Simple;
 use Email::MIME;
 use Data::Dumper;
 use PAUSE::Web::Exception;
+use Crypt::URandom;
 
 our $VERSION = "1072";
 
+has secrets => sub { [ unpack 'H*', Crypt::URandom::urandom(32) ] };
 has root => sub { Carp::confess "requires root" };
 has config => sub { require PAUSE::Web::Config; PAUSE::Web::Config->new };
 has logger => sub { Log::Dispatch::Config->instance };

--- a/lib/pause_2017/PAUSE/Web/Context.pm
+++ b/lib/pause_2017/PAUSE/Web/Context.pm
@@ -8,13 +8,12 @@ use Sys::Hostname ();
 use Email::Sender::Simple;
 use Email::MIME;
 use Data::Dumper;
-use PAUSE::Web::Config;
 use PAUSE::Web::Exception;
 
 our $VERSION = "1072";
 
 has root => sub { Carp::confess "requires root" };
-has config => sub { PAUSE::Web::Config->new };
+has config => sub { require PAUSE::Web::Config; PAUSE::Web::Config->new };
 has logger => sub { Log::Dispatch::Config->instance };
 has mailer => sub { Email::Sender::Simple->new };
 


### PR DESCRIPTION
This PR is intended to make it easier to extend the current PAUSE Web UI.

With this, we can add files such as `lib/pause_2026/PAUSE/Web2026/Controller/ForNewFeature.pm` and `lib/pause_2026/templates/for_new_feature.html.ep`  without modifying files under `lib/pause_2017` (or adding new files under 'lib/pause_2017` ) .

Also, this fixes the wrong usage of `$app->secrets`. 