### PR TITLE
Replace Path::Class used in tests with Path::Tiny

### DIFF
--- a/t/lib/PAUSE/TestPAUSE.pm
+++ b/t/lib/PAUSE/TestPAUSE.pm
@@ -13,7 +13,7 @@ use File::Path qw(make_path);
 use File::pushd;
 use File::Temp ();
 use File::Which;
-use Path::Class;
+use Path::Tiny;
 use Process::Status;
 
 # This one, we don't expect to be used.  In a weird world, we'd mark it fatal
@@ -36,12 +36,12 @@ sub init_new {
   my ($class, @arg) = @_;
   my $self = $class->new(@arg);
 
-  my $authors_dir = $self->tmpdir->subdir(qw(cpan authors id));
+  my $authors_dir = $self->tmpdir->child(qw(cpan authors id));
   make_path $authors_dir->stringify;
 
-  my $modules_dir = $self->tmpdir->subdir(qw(cpan modules));
+  my $modules_dir = $self->tmpdir->child(qw(cpan modules));
   make_path $modules_dir->stringify;
-  my $index_06 = $modules_dir->file(qw(06perms.txt.gz));
+  my $index_06 = $modules_dir->child(qw(06perms.txt.gz));
 
   {
     File::Copy::copy('corpus/empty.txt.gz', $index_06->stringify)
@@ -78,7 +78,7 @@ has _tmpdir_obj => (
 has tmpdir => (
   is      => 'ro',
   lazy    => 1,
-  default => sub { dir($_[0]->_tmpdir_obj) },
+  default => sub { path($_[0]->_tmpdir_obj) },
 );
 
 has email_sender_transport => (
@@ -381,15 +381,9 @@ sub test_reindex {
         for @{ $arg->{pick} };
     }
 
-    my sub filestate ($file) {
-      return ';;' unless -e $file;
-      my @stat = stat $file;
-      return join q{;}, @stat[0,1,7]; # dev, ino, size
-    }
+    my $package_file = $self->tmpdir->child(qw(cpan modules 02packages.details.txt.gz));
 
-    my $package_file = $self->tmpdir->file(qw(cpan modules 02packages.details.txt.gz));
-
-    my $old_package_state = filestate($package_file);
+    my $old_package_state = -f $package_file ? $package_file->digest : '';
 
     PAUSE::mldistwatch->new({
       sleep => 0,
@@ -407,7 +401,7 @@ sub test_reindex {
 
     Email::Sender::Simple->default_transport->clear_deliveries;
 
-    my $new_package_state = filestate($package_file);
+    my $new_package_state = -f $package_file ? $package_file->digest : '';
 
     return PAUSE::TestPAUSE::Result->new({
       tmpdir => $self->tmpdir,

--- a/t/lib/PAUSE/TestPAUSE/Result.pm
+++ b/t/lib/PAUSE/TestPAUSE/Result.pm
@@ -52,12 +52,12 @@ sub connect_mod_db {
 sub packages_data {
   my ($self) = @_;
 
-  unless (-e $self->tmpdir->file(qw(cpan modules 02packages.details.txt.gz))) {
+  unless (-e $self->tmpdir->child(qw(cpan modules 02packages.details.txt.gz))) {
     return Parse::CPAN::Packages->new("Description:");
   }
 
   return Parse::CPAN::Packages->new(
-    q{} . $self->tmpdir->file(qw(cpan modules 02packages.details.txt.gz)),
+    q{} . $self->tmpdir->child(qw(cpan modules 02packages.details.txt.gz)),
   );
 }
 
@@ -110,8 +110,7 @@ sub perm_list_ok {
 
   local $Test::Builder::Level = $Test::Builder::Level + 1;
 
-  my $index_06 = $self->tmpdir->subdir(qw(cpan modules))
-                 ->file(qw(06perms.txt.gz));
+  my $index_06 = $self->tmpdir->child(qw(cpan modules 06perms.txt.gz));
 
   our $GZIP = $PAUSE::Config->{GZIP_PATH};
   open my $fh, "-|", "$GZIP --stdout --uncompress $index_06"

--- a/t/mldistwatch-big.t
+++ b/t/mldistwatch-big.t
@@ -54,8 +54,8 @@ subtest "first indexing" => sub {
 
   subtest "meagre git tests" => sub {
     ok(
-      -e $result->tmpdir->file('git/.git/refs/heads/master')
-        || -e $result->tmpdir->file('git/.git/refs/heads/main'),
+      -e $result->tmpdir->child('git/.git/refs/heads/master')
+        || -e $result->tmpdir->child('git/.git/refs/heads/main'),
       "we now have a master or main commit",
     );
   };

--- a/t/mldistwatch-misc.t
+++ b/t/mldistwatch-misc.t
@@ -65,7 +65,7 @@ sub refused_index_test {
 
     $result->package_list_ok($arg->{want_package_list});
 
-    my $file = $pause->tmpdir->subdir(qw(cpan modules))->file('06perms.txt');
+    my $file = $pause->tmpdir->child(qw(cpan modules 06perms.txt));
   };
 };
 
@@ -452,10 +452,10 @@ subtest "sort of case-conflicted packages is stable" => sub {
   $dbh->do("INSERT INTO distmtimes ('dist','distmtime') VALUES ('O/OP/OPRIME/Bug-Gold-1.001.tar.gz','$now')");
 
   for my $fn (qw(Bug-gold-0.001.tar.gz Bug-Gold-1.001.tar.gz)) {
-    my $dir = $pause->tmpdir->subdir( qw(cpan authors id O OP OPRIME) );
+    my $dir = $pause->tmpdir->child( qw(cpan authors id O OP OPRIME) );
     $dir->mkpath;
 
-    open my $fh, ">", $dir->file($fn) or die "Could not open: $!";
+    open my $fh, ">", $dir->child($fn) or die "Could not open: $!";
     print $fh qq<fake tarball>;
     close $fh or die "Could not close: $!";
   }


### PR DESCRIPTION
Should fix #526, though I haven't fixed Path::Class usage in lib/PAUSE/mldistwatch.pm and one-off-utils/build-fresh-cpan , and thus I haven't updated Makefile.PL and cpanfile yet.