### PR TITLE
Remove insecure links

### DIFF
--- a/lib/pause_2017/templates/email/admin/user/onetime_password.email.ep
+++ b/lib/pause_2017/templates/email/admin/user/onetime_password.email.ep
@@ -16,10 +16,7 @@ you to pick your own password. This password is "<%== $pause->{onetime} %>"
 
 and use this password to initialize your account in the authentication
 database. Once you have entered your password there, your one-time
-password is expired automatically. If you cannot connect to the above
-URL, you can replace 'https' with 'http', but then you are not using
-SSL encryption. Be careful to always use an SSL connection if
-possible, otherwise your password can be intercepted by third parties.
+password is expired automatically.
 
 Thanks & Regards,
 --

--- a/lib/pause_2017/templates/email/admin/user/welcome_user.email.ep
+++ b/lib/pause_2017/templates/email/admin/user/welcome_user.email.ep
@@ -24,8 +24,6 @@ database dumps. You can register with both a public and a secret email
 if you want to protect yourself from SPAM. If you want to do this,
 please visit
   <%== my_full_url->path("/pause/authenquery")->query(ACTION => "edit_cred" )->scheme("https") %>
-or
-  <%== my_full_url->path("/pause/authenquery")->query(ACTION => "edit_cred" )->scheme("http") %>
 
 If you need any further information, please visit
   $CPAN/modules/04pause.html.

--- a/lib/pause_2017/templates/email/user/delete_files.email.ep
+++ b/lib/pause_2017/templates/email/user/delete_files.email.ep
@@ -7,8 +7,7 @@ According to a request entered by <%== $pause->{User}{fullname} %> the
 following files and the symlinks pointing to them have been scheduled
 for deletion. They will expire after 72 hours and then be deleted by a
 cronjob. Until then you can undelete them via
-<%== my_full_url->path("/pause/authenquery")->query(ACTION => "delete_files")->scheme("https") %> or
-<%== my_full_url->path("/pause/authenquery")->query(ACTION => "delete_files")->scheme("http") %>
+<%== my_full_url->path("/pause/authenquery")->query(ACTION => "delete_files")->scheme("https") %>
 % end
 
 <%== $pause->{blurb} %>

--- a/lib/pause_2017/templates/email/user/delete_files.email.ep
+++ b/lib/pause_2017/templates/email/user/delete_files.email.ep
@@ -14,7 +14,7 @@ cronjob. Until then you can undelete them via
 
 %= text_format begin
 Note: to encourage deletions, all of past CPAN
-glory is collected on http://history.perl.org/backpan/
+glory is collected on https://backpan.perl.org/
 % end
 
 The PAUSE Team

--- a/lib/pause_2017/templates/public/request_id/_form.html.ep
+++ b/lib/pause_2017/templates/public/request_id/_form.html.ep
@@ -3,7 +3,7 @@
 
 <p>A PAUSE account is only required to distribute and manage Perl module
 distributions on CPAN. You do not need a PAUSE account to submit
-bug reports to <a href="http://rt.cpan.org/">RT</a> or participate
+bug reports to <a href="https://rt.cpan.org/">RT</a> or participate
 in many Perl community sites.</p>
 
 <div class="alternate<%= $alt++ % 2 + 1 %>">

--- a/lib/pause_2017/templates/user/edit_uris.html.ep
+++ b/lib/pause_2017/templates/user/edit_uris.html.ep
@@ -35,7 +35,7 @@ to fix <i>broken</i> uploads that cannot be completed, not an
 opportunity to turn the time back.
 
 <p> To re-iterate: If you change the content of this field to
-<b>http://www.slashdot.org/</b>, PAUSE will fetch the current
+<b>https://slashdot.org/</b>, PAUSE will fetch the current
 Slashdot page and will put it into
 <b><%= $pause->{selected}{uriid} %></b>. If you change it to
 <b>FooBar-3.14.tar.gz</b>, PAUSE will try to get
@@ -43,8 +43,8 @@ Slashdot page and will put it into
 finds it, it puts it into <b><%= $pause->{selected}{uriid} %></b>.</p>
 
 <p>An example: if you made a typo and requested to upload
-<b>http://badsite.org/foo</b> instead of
-<b>http://goodsite.org/foo</b>, just correct the thing in the
+<b>https://badsite.org/foo</b> instead of
+<b>https://goodsite.org/foo</b>, just correct the thing in the
 textfield below.</p>
 
 <p>Another example: If your upload was unsuccessful and you now have

--- a/lib/pause_2017/templates/user/uri/_continued.html.ep
+++ b/lib/pause_2017/templates/user/uri/_continued.html.ep
@@ -23,7 +23,7 @@ of a module on several hundred mirrors. Please consider <a
 href="<%= my_url->query(ACTION => "delete_files") %>">removing</a> old versions of
 your module from PAUSE and CPAN. If you are worried that someone might
 need an old version, it can always be found on the <a
-href="http://backpan.cpan.org/authors/id/<%= $pause->{userhome} %>/">backpan</a>
+href="https://backpan.perl.org/authors/id/<%= $pause->{userhome} %>/">backpan</a>
 </p>
 
 <p><b>Debugging:</b> your submission should show up soon at <a


### PR DESCRIPTION
Now we shouldn't embed an insecure link in emails we send to users.