### PR TITLE
Remove cpan.org email forwarding options and add shutdown/cpan-security notices

### DIFF
--- a/lib/pause_2017/PAUSE/Web/Config.pm
+++ b/lib/pause_2017/PAUSE/Web/Config.pm
@@ -451,7 +451,6 @@ our %Actions = (
       pause99_edit_cred_email => {form_type => "text_field"},
       pause99_edit_cred_secretemail => {form_type => "text_field"},
       pause99_edit_cred_homepage => {form_type => "text_field"},
-      pause99_edit_cred_cpan_mail_alias => {form_type => "radio_button"},
       pause99_edit_cred_ustatus => {form_type => "check_box"}, # to delete
       pause99_edit_cred_sub => {form_type => "submit_button"},
     },

--- a/lib/pause_2017/PAUSE/Web/Controller/Admin.pm
+++ b/lib/pause_2017/PAUSE/Web/Controller/Admin.pm
@@ -14,35 +14,22 @@ sub email_for_admin {
     my $dbm = $mgr->connect;
     my $sth1 = $dbm->prepare(qq{SELECT userid, email
                                 FROM   users
-                                WHERE  isa_list = ''
-                                  AND  (
-                                        cpan_mail_alias='publ'
-                                        OR
-                                        cpan_mail_alias='secr'
-                                       )});
+                                WHERE  isa_list = ''});
     $sth1->execute;
     while (my($id,$mail) = $sth1->fetchrow_array) {
-      $ALL{$id} = $mail; # we store public email even for those who want
-                         # secret, because we never know if we will find a
-                         # secret one
+      $ALL{$id} = $mail; # store public email as baseline
     }
     $sth1->finish;
-    my $sth2 = $dbm->prepare(qq{SELECT userid
-                                FROM   users
-                                WHERE  cpan_mail_alias='secr'
-                                  AND  isa_list = ''});
+
+    my $sth2 = $dba->prepare(qq{SELECT user, secretemail
+                                FROM   usertable});
     $sth2->execute;
-    my $sth3 = $dba->prepare(qq{SELECT secretemail
-                                FROM   usertable
-                                WHERE  user=?});
-    while (my($id) = $sth2->fetchrow_array) {
-      $sth3->execute($id);
-      next unless $sth3->rows;
-      my($mail) = $sth3->fetchrow_array or next;
-      $ALL{$id} = $mail;
+    while (my($id,$mail) = $sth2->fetchrow_array) {
+      if (exists $ALL{$id} && defined $mail && $mail ne '') {
+        $ALL{$id} = $mail; # override with secret email if available
+      }
     }
     $sth2->finish;
-    $sth3->finish;
   };
   my $output_format = $req->param("OF");
   if ($output_format){

--- a/lib/pause_2017/PAUSE/Web/Controller/User/Cred.pm
+++ b/lib/pause_2017/PAUSE/Web/Controller/User/Cred.pm
@@ -14,9 +14,9 @@ sub edit {
   $u = $c->active_user_record;
 
   # @allmeta *must* be the union of meta and secmeta
-  my @meta = qw( fullname asciiname email homepage cpan_mail_alias ustatus);
+  my @meta = qw( fullname asciiname email homepage ustatus);
   my @secmeta = qw(secretemail);
-  my @allmeta = qw( fullname asciiname email secretemail homepage cpan_mail_alias ustatus);
+  my @allmeta = qw( fullname asciiname email secretemail homepage ustatus);
 
   my $cpan_alias = lc($u->{userid}) . '@cpan.org';
 
@@ -26,18 +26,9 @@ sub edit {
   if (uc $req->method eq 'POST' and $req->param("pause99_edit_cred_sub")) {
     my $wantemail = $req->param("pause99_edit_cred_email");
     my $wantsecretemail = $req->param("pause99_edit_cred_secretemail");
-    my $wantalias = $req->param("pause99_edit_cred_cpan_mail_alias");
     my $addr_spec = $Email::Address::addr_spec;
     if ($wantemail=~/^\s*$/ && $wantsecretemail=~/^\s*$/) {
       $pause->{error}{no_email} = 1;
-    } elsif ($wantalias eq "publ" && $wantemail=~/^\s*$/) {
-      $pause->{error}{no_public_email} = 1;
-    } elsif ($wantalias eq "publ" && $wantemail=~/\Q$cpan_alias\E/i) {
-      $pause->{error}{public_is_cpan_alias} = 1;
-    } elsif ($wantalias eq "secr" && $wantsecretemail=~/^\s*$/) {
-      $pause->{error}{no_secret_email} = 1;
-    } elsif ($wantalias eq "secr" && $wantsecretemail=~/\Q$cpan_alias\E/i) {
-      $pause->{error}{secret_is_cpan_alias} = 1;
     } elsif (defined $wantsecretemail && $wantsecretemail!~/^\s*$/ && $wantsecretemail!~/^\s*$addr_spec\s*$/) {
       $pause->{error}{invalid_secret} = 1;
     } elsif (defined $wantemail && $wantemail!~/^\s*$/ && $wantemail!~/^\s*$addr_spec\s*$/ && $wantemail ne 'CENSORED') {

--- a/lib/pause_2017/templates/admin/email_for_admin.html.ep
+++ b/lib/pause_2017/templates/admin/email_for_admin.html.ep
@@ -9,7 +9,7 @@
   <thead>
     <tr>
       <th class="sort asc" data-sort="userid">id</th>
-      <th class="sort" data-sort="email"><i>id</i>@cpan.org gets forwarded to</th>
+      <th class="sort" data-sort="email">Contact Email</th>
     </tr>
   </thead>
   <tbody class="list">

--- a/lib/pause_2017/templates/public/request_id/_form.html.ep
+++ b/lib/pause_2017/templates/public/request_id/_form.html.ep
@@ -23,6 +23,7 @@ Note: You can enter fairly free-form text here but it must consist of at least t
 <p>
 <%= text_field "pause99_request_id_email", size => 32 %>
 </p>
+<p><small>Note that contact information will be shared with the CPAN security team (<a href="https://security.cpan.org/">security.cpan.org</a>).</small></p>
 </div>
 
 <div class="alternate<%= $alt++ % 2 + 1 %>">

--- a/lib/pause_2017/templates/user/cred/edit.html.ep
+++ b/lib/pause_2017/templates/user/cred/edit.html.ep
@@ -16,14 +16,6 @@
 <b>ERROR</b>:
 %     if ($error->{no_email}) {
 Both of your email fields are left blank, this is not the way it is intended on PAUSE, PAUSE must be able to contact you. Please fill out at least one of the two email fields.
-%     } elsif ($error->{no_public_email}) {
-You chose your email alias on CPAN to point to your public email address but your public email address is left blank. Please either pick a different choice for the alias or fill in a public email address.
-%     } elsif ($error->{public_is_cpan_alias}) {
-You chose your email alias on CPAN to point to your public email address but your public email address field contains <%= $cpan_alias %>. This looks like a circular reference. Please either pick a different choice for the alias or fill in a more reasonable public email address.
-%     } elsif ($error->{no_secret_email}) {
-You chose your email alias on CPAN to point to your secret email address but your secret email address is left blank. Please either pick a different choice for the alias or fill in a secret email address.
-%     } elsif ($error->{secret_is_cpan_alias}) {
-You chose your email alias on CPAN to point to your secret email address but your secret email address field contains <%= $cpan_alias %>. This looks like a circular reference. Please either pick a different choice for the alias or fill in a more reasonable secret email address.
 %     } elsif ($error->{invalid_secret}) {
 Your secret email address doesn't look like valid email address.
 %     } elsif ($error->{invalid_public}) {
@@ -108,25 +100,17 @@ for communicating with you.
 %>
 </td></tr>
 
-<tr><td class="alternate<%= $alter++ % 2 + 1 %>"><h4 class="altering">The email address <i><%= $cpan_alias %></i> should be configured to forward mail to ...</h4>
+<tr><td class="alternate<%= $alter++ % 2 + 1 %>"><h4 class="altering">Security Notice</h4>
 <p class="explain">
-<b>cpan.org</b> has a mail
-address for you and it's your choice if you want it to point to your
-public email address or to your secret one. Please allow a few hours
-for any change you make to this setting for propagation. BTW, let us
-reassure you that cpan.org gets the data through a secure
-channel.<br><br><b>Note:</b> you can disable redirect by clicking
-<i>neither nor</i> or by using an invalid email address in the
-according field above, but this will prevent you from recieving
-emails from services like rt.cpan.org.
+Contact information will be shared with the CPAN security team (<a href="https://security.cpan.org/">security.cpan.org</a>).
 </p>
-<%= radio_button "pause99_edit_cred_cpan_mail_alias" => "publ" %>
-my public email address<br>
-<%= radio_button "pause99_edit_cred_cpan_mail_alias" => "secr" %>
-my secret email address<br>
-<%= radio_button "pause99_edit_cred_cpan_mail_alias" => "none",
-    checked => "checked",
-%> neither nor<br>
+</td></tr>
+
+<tr><td class="alternate<%= $alter++ % 2 + 1 %>"><h4 class="altering">cpan.org email forwarding</h4>
+<p class="explain">
+cpan.org email forwarding has been shut down.
+See <a href="https://log.perl.org/2026/04/cpanorg-email-forwarding-has-been-shut.html">this blog post</a> for more information.
+</p>
 </td></tr>
 
 % if ($pause->{HiddenUser}{ustatus} ne "active") {

--- a/t/pause_2017/action/edit_cred.t
+++ b/t/pause_2017/action/edit_cred.t
@@ -9,7 +9,6 @@ my $default = {
     pause99_edit_cred_asciiname => "new ascii name",
     pause99_edit_cred_email => "new_email\@localhost.localdomain",
     pause99_edit_cred_homepage => "none",
-    pause99_edit_cred_cpan_mail_alias => "none",
     pause99_edit_cred_sub => 1,
 };
 


### PR DESCRIPTION

I was unable to test this locally, because I don't have a great pause dev environment.  It intentionally just modifies the frontend.