### PR TITLE
Suppress uuv

### DIFF
--- a/lib/pause_2017/PAUSE/Web/Config.pm
+++ b/lib/pause_2017/PAUSE/Web/Config.pm
@@ -96,6 +96,7 @@ our %Actions = (
   who_pumpkin => {
     x_mojo_to => "public#pumpkin",
     priv => "public",
+    cat => "02serv/05",
     display => 0,
   },
   who_admin => {


### PR DESCRIPTION
Apparently an older version of #579 has been merged. This PR is to add the missing commit.